### PR TITLE
Fix Issue #4

### DIFF
--- a/lib/tutorial_coach_mark_widget.dart
+++ b/lib/tutorial_coach_mark_widget.dart
@@ -76,11 +76,15 @@ class _TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget> {
       stream: _controllerFade.stream,
       initialData: 0.0,
       builder: (_, snapshot) {
-        return AnimatedOpacity(
-          opacity: snapshot.data,
-          duration: Duration(milliseconds: 300),
-          child: _buildPositionedsContents(),
-        );
+        try {
+          return AnimatedOpacity(
+            opacity: snapshot.data,
+            duration: Duration(milliseconds: 300),
+            child: _buildPositionedsContents(),
+          );
+        } catch (err) {
+          return Container();
+        }
       },
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tutorial_coach_mark
 description: Guide that helps you to present your app and its features in a beautiful, simple and customizable way.
-version: 0.1.1
+version: 0.1.2
 author: RafaelBarbosatec<rafaelbarbosatec@gmail.com>
 homepage: https://github.com/RafaelBarbosatec/tutorial_coach_mark
 


### PR DESCRIPTION
I would like to explain further on issue #4, if the page is composed of multiple widgets from multiple dart file:

e.g. A scaffold widget contains body(in separate dart file) and bottomnavigationbar (in separate dart file)

and

1. there is a tutorial_coach_mark target inside the bottomnavigationbaritem

2. after this target's tutorial coach mark is shown, switch to another app.

3. go back to this app and click Skip. Since I'm using the didChangeAppLifecycleState to detect whether the user has left the current app, and I need to refresh the scaffold widget after resume.  When I refresh the scaffold, the tutorial coach mark is already shown, however, a new bottomnavigationbar is generated and built.  Which means that the original Globalkey does not exist anymore.

And the 'RED SCREEN' error as stated in issue #4 will be shown.

To fix this error: I found the location of the error @ lib/tutorial_coach_mark_widget.dart and I simply try catch this error so that the 'RED SCREEN' does not show any more and everything is fine.

I believe this 'Try Catch' will have NO EFFECT on others if they don't have this kind of error but does help some others which requires a refresh of the page after 'RESUME'.

Pls. take a look at the code below, I only replace the AnimatedOpacity widget with an empty container() widget when there is any error.

Thank you for your attention.