### PR TITLE
Fix #8 Change on the current callbacks

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -342,8 +342,10 @@ class _MyHomePageState extends State<MyHomePage> {
         colorShadow: Colors.red,
         textSkip: "SKIP",
         paddingFocus: 10,
-        opacityShadow: 0.8, finish: () {
-      print("finish");
+        opacityShadow: 0.8, onDispose: () {
+      print("onDispose");
+    }, onTutorialEnd: () {
+      print("onTutorialEnd");
     }, clickTarget: (target) {
       print(target);
     }, clickSkip: () {

--- a/lib/animated_focus_light.dart
+++ b/lib/animated_focus_light.dart
@@ -15,7 +15,8 @@ class AnimatedFocusLight extends StatefulWidget {
   final Function(TargetFocus) focus;
   final Function(TargetFocus) clickTarget;
   final Function removeFocus;
-  final Function() finish;
+  final Function() onTutorialEnd;
+  final Function() onDispose;
   final double paddingFocus;
   final Color colorShadow;
   final double opacityShadow;
@@ -25,7 +26,8 @@ class AnimatedFocusLight extends StatefulWidget {
     Key key,
     this.targets,
     this.focus,
-    this.finish,
+    this.onTutorialEnd,
+    this.onDispose,
     this.removeFocus,
     this.clickTarget,
     this.paddingFocus = 10,
@@ -180,7 +182,8 @@ class _AnimatedFocusLightState extends State<AnimatedFocusLight>
         currentFocus = -1;
       });
 
-      widget.finish();
+      widget.onDispose();
+      if (widget.onTutorialEnd != null) widget.onTutorialEnd();
       return;
     }
 

--- a/lib/tutorial_coach_mark.dart
+++ b/lib/tutorial_coach_mark.dart
@@ -10,9 +10,10 @@ class TutorialCoachMark {
   final BuildContext _context;
   final List<TargetFocus> targets;
   final Function(TargetFocus) clickTarget;
-  final Function() finish;
+  final Function() onDispose;
   final double paddingFocus;
   final Function() clickSkip;
+  final Function() onTutorialEnd;
   final AlignmentGeometry alignSkip;
   final String textSkip;
   final Color colorShadow;
@@ -25,9 +26,10 @@ class TutorialCoachMark {
     this.targets,
     this.colorShadow = Colors.black,
     this.clickTarget,
-    this.finish,
+    this.onDispose,
     this.paddingFocus = 10,
     this.clickSkip,
+    this.onTutorialEnd,
     this.alignSkip = Alignment.bottomRight,
     this.textSkip = "SKIP",
     this.opacityShadow = 0.8,
@@ -44,9 +46,10 @@ class TutorialCoachMark {
         textSkip: textSkip,
         colorShadow: colorShadow,
         opacityShadow: opacityShadow,
-        finish: () {
+        onTutorialEnd: onTutorialEnd,
+        onDispose: () {
           _hide();
-          if (finish != null) finish();
+          if (onDispose != null) onDispose();
         },
       );
     });

--- a/lib/tutorial_coach_mark_widget.dart
+++ b/lib/tutorial_coach_mark_widget.dart
@@ -10,24 +10,26 @@ import 'package:tutorial_coach_mark/util.dart';
 class TutorialCoachMarkWidget extends StatefulWidget {
   final List<TargetFocus> targets;
   final Function(TargetFocus) clickTarget;
-  final Function() finish;
+  final Function() onDispose;
   final Color colorShadow;
   final double opacityShadow;
   final double paddingFocus;
   final Function() clickSkip;
+  final Function() onTutorialEnd;
   final AlignmentGeometry alignSkip;
   final String textSkip;
   const TutorialCoachMarkWidget(
       {Key key,
-      this.targets,
-      this.finish,
-      this.paddingFocus = 10,
-      this.clickTarget,
-      this.alignSkip = Alignment.bottomRight,
-      this.textSkip = "SKIP",
-      this.clickSkip,
-      this.colorShadow = Colors.black,
-      this.opacityShadow = 0.8})
+        this.targets,
+        this.onDispose,
+        this.paddingFocus = 10,
+        this.clickTarget,
+        this.alignSkip = Alignment.bottomRight,
+        this.textSkip = "SKIP",
+        this.clickSkip,
+        this.onTutorialEnd,
+        this.colorShadow = Colors.black,
+        this.opacityShadow = 0.8})
       : super(key: key);
 
   @override
@@ -49,7 +51,8 @@ class _TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget> {
         children: <Widget>[
           AnimatedFocusLight(
             targets: widget.targets,
-            finish: widget.finish,
+            onDispose: widget.onDispose,
+            onTutorialEnd: widget.onTutorialEnd,
             paddingFocus: widget.paddingFocus,
             colorShadow: widget.colorShadow,
             opacityShadow: widget.opacityShadow,
@@ -183,7 +186,7 @@ class _TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget> {
             duration: Duration(milliseconds: 300),
             child: InkWell(
               onTap: () {
-                widget.finish();
+                widget.onDispose();
                 if (widget.clickSkip != null) {
                   widget.clickSkip();
                 }


### PR DESCRIPTION
Fix #8 adding new callback and changing the name of `finish`
Currently the callbacks we have are:
- onDispose: when the screen is hidden
- onTutorialEnd: when the user sees through the tutorial
- clickSkip: when the user clicks skip