### PR TITLE
Add Option to Disable Overlay Tap Handler

### DIFF
--- a/lib/animated_focus_light.dart
+++ b/lib/animated_focus_light.dart
@@ -20,6 +20,7 @@ class AnimatedFocusLight extends StatefulWidget {
   final Color colorShadow;
   final double opacityShadow;
   final Stream<void> streamTap;
+  final bool disableOverlayTap;
 
   const AnimatedFocusLight({
     Key key,
@@ -32,14 +33,14 @@ class AnimatedFocusLight extends StatefulWidget {
     this.colorShadow = Colors.black,
     this.opacityShadow = 0.8,
     this.streamTap,
+    this.disableOverlayTap = false,
   }) : super(key: key);
 
   @override
   _AnimatedFocusLightState createState() => _AnimatedFocusLightState();
 }
 
-class _AnimatedFocusLightState extends State<AnimatedFocusLight>
-    with TickerProviderStateMixin {
+class _AnimatedFocusLightState extends State<AnimatedFocusLight> with TickerProviderStateMixin {
   AnimationController _controller;
   AnimationController _controllerPulse;
   CurvedAnimation _curvedAnimation;
@@ -55,8 +56,7 @@ class _AnimatedFocusLightState extends State<AnimatedFocusLight>
 
   @override
   void initState() {
-    _controller =
-        AnimationController(vsync: this, duration: Duration(milliseconds: 600));
+    _controller = AnimationController(vsync: this, duration: Duration(milliseconds: 600));
     _controller
       ..addStatusListener((status) {
         if (status == AnimationStatus.completed) {
@@ -82,8 +82,7 @@ class _AnimatedFocusLightState extends State<AnimatedFocusLight>
 
     _curvedAnimation = CurvedAnimation(parent: _controller, curve: Curves.ease);
 
-    _controllerPulse =
-        AnimationController(vsync: this, duration: Duration(milliseconds: 500));
+    _controllerPulse = AnimationController(vsync: this, duration: Duration(milliseconds: 500));
     _controllerPulse.addStatusListener((status) {
       if (status == AnimationStatus.completed) {
         _controllerPulse.reverse();
@@ -101,8 +100,7 @@ class _AnimatedFocusLightState extends State<AnimatedFocusLight>
       }
     });
 
-    tweenPulse = Tween(begin: 1.0, end: 0.99)
-        .animate(CurvedAnimation(parent: _controllerPulse, curve: Curves.ease));
+    tweenPulse = Tween(begin: 1.0, end: 0.99).animate(CurvedAnimation(parent: _controllerPulse, curve: Curves.ease));
 
     WidgetsBinding.instance.addPostFrameCallback(_afterLayout);
     widget.streamTap.listen((_) {
@@ -134,8 +132,7 @@ class _AnimatedFocusLightState extends State<AnimatedFocusLight>
                     height: double.maxFinite,
                     child: currentFocus != -1
                         ? CustomPaint(
-                            painter: widget?.targets[currentFocus]?.shape ==
-                                    ShapeLightFocus.RRect
+                            painter: widget?.targets[currentFocus]?.shape == ShapeLightFocus.RRect
                                 ? LightPaintRect(
                                     colorShadow: widget.colorShadow,
                                     positioned: positioned,
@@ -163,12 +160,14 @@ class _AnimatedFocusLightState extends State<AnimatedFocusLight>
   }
 
   void _tapHandler() {
-    setState(() {
-      initReverse = true;
-      _controllerPulse.reverse(from: _controllerPulse.value);
-    });
-    if (currentFocus > -1) {
-      widget?.clickTarget(widget.targets[currentFocus]);
+    if (widget.disableOverlayTap == false) {
+      setState(() {
+        initReverse = true;
+        _controllerPulse.reverse(from: _controllerPulse.value);
+      });
+      if (currentFocus > -1) {
+        widget?.clickTarget(widget.targets[currentFocus]);
+      }
     }
   }
 

--- a/lib/tutorial_coach_mark.dart
+++ b/lib/tutorial_coach_mark.dart
@@ -18,6 +18,7 @@ class TutorialCoachMark {
   final TextStyle textStyleSkip;
   final Color colorShadow;
   final double opacityShadow;
+  final bool disableOverlayTap;
 
   OverlayEntry _overlayEntry;
 
@@ -33,6 +34,7 @@ class TutorialCoachMark {
     this.textSkip = "SKIP",
     this.textStyleSkip = const TextStyle(color: Colors.white),
     this.opacityShadow = 0.8,
+    this.disableOverlayTap = false,
   }) : assert(targets != null, opacityShadow >= 0 && opacityShadow <= 1);
 
   OverlayEntry _buildOverlay() {
@@ -50,6 +52,7 @@ class TutorialCoachMark {
         finish: () {
           hide();
         },
+        disableOverlayTap: disableOverlayTap,
       );
     });
   }

--- a/lib/tutorial_coach_mark_widget.dart
+++ b/lib/tutorial_coach_mark_widget.dart
@@ -18,6 +18,7 @@ class TutorialCoachMarkWidget extends StatefulWidget {
   final AlignmentGeometry alignSkip;
   final String textSkip;
   final TextStyle textStyleSkip;
+  final bool disableOverlayTap;
 
   const TutorialCoachMarkWidget(
       {Key key,
@@ -30,7 +31,8 @@ class TutorialCoachMarkWidget extends StatefulWidget {
       this.clickSkip,
       this.colorShadow = Colors.black,
       this.opacityShadow = 0.8,
-      this.textStyleSkip = const TextStyle(color: Colors.white)})
+      this.textStyleSkip = const TextStyle(color: Colors.white),
+      this.disableOverlayTap = false})
       : super(key: key);
 
   @override
@@ -67,6 +69,7 @@ class _TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget> {
               _controllerFade.sink.add(0.0);
             },
             streamTap: _controllerTapChild.stream,
+            disableOverlayTap: widget.disableOverlayTap,
           ),
           _buildContents(),
           _buildSkip()


### PR DESCRIPTION
I have a use case where I want to guide the user through performing several actions. By being able to disable the overlay tap, it will force the user to perform the actions and not skip past them by tapping the overlay.