### PR TITLE
TutorialCoachMark should distinguishably callback skip & finish events.

### DIFF
--- a/lib/tutorial_coach_mark.dart
+++ b/lib/tutorial_coach_mark.dart
@@ -3,6 +3,7 @@ library tutorial_coach_mark;
 import 'package:flutter/material.dart';
 import 'package:tutorial_coach_mark/target_focus.dart';
 import 'package:tutorial_coach_mark/tutorial_coach_mark_widget.dart';
+
 export 'package:tutorial_coach_mark/content_target.dart';
 export 'package:tutorial_coach_mark/target_focus.dart';
 
@@ -43,7 +44,7 @@ class TutorialCoachMark {
         targets: targets,
         clickTarget: clickTarget,
         paddingFocus: paddingFocus,
-        clickSkip: clickSkip,
+        clickSkip: skip,
         alignSkip: alignSkip,
         textSkip: textSkip,
         textStyleSkip: textStyleSkip,
@@ -66,6 +67,15 @@ class TutorialCoachMark {
 
   void hide() {
     if (finish != null) finish();
+    _removeOverlay();
+  }
+
+  void skip() {
+    if (clickSkip != null) clickSkip();
+    _removeOverlay();
+  }
+
+  void _removeOverlay() {
     _overlayEntry?.remove();
     _overlayEntry = null;
   }

--- a/lib/tutorial_coach_mark_widget.dart
+++ b/lib/tutorial_coach_mark_widget.dart
@@ -200,10 +200,7 @@ class _TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget> {
               opacity: snapshot.data,
               duration: Duration(milliseconds: 300),
               child: InkWell(
-                onTap: () {
-                  widget.finish();
-                  widget.clickSkip();
-                },
+                onTap: widget.clickSkip,
                 child: Padding(
                   padding: const EdgeInsets.all(20.0),
                   child: Text(

--- a/lib/tutorial_coach_mark_widget.dart
+++ b/lib/tutorial_coach_mark_widget.dart
@@ -202,9 +202,7 @@ class _TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget> {
               child: InkWell(
                 onTap: () {
                   widget.finish();
-                  if (widget.clickSkip != null) {
-                    widget.clickSkip();
-                  }
+                  widget.clickSkip();
                 },
                 child: Padding(
                   padding: const EdgeInsets.all(20.0),


### PR DESCRIPTION
**Current behavior**
When the user presses the skip button, he is given callback of the finish event first & then skip event.

**Expected behavior**
When a user presses the skip button, TutorialCoachMark should not callback for the finish event. Instead, let the user decide what should happen on skip & finish callbacks individually.

Although both skip & finish events denote that the active overlay should be removed from the screen, so the class should remove that overlay anyhow which is happening in the existing solution.