### PR TITLE
Differentiate between overlay clicks and target clicks

### DIFF
--- a/lib/animated_focus_light.dart
+++ b/lib/animated_focus_light.dart
@@ -12,6 +12,7 @@ class AnimatedFocusLight extends StatefulWidget {
   final List<TargetFocus> targets;
   final Function(TargetFocus) focus;
   final Function(TargetFocus) clickTarget;
+  final Function(TargetFocus) clickOverlay;
   final Function removeFocus;
   final Function() finish;
   final double paddingFocus;
@@ -27,6 +28,7 @@ class AnimatedFocusLight extends StatefulWidget {
     this.finish,
     this.removeFocus,
     this.clickTarget,
+    this.clickOverlay,
     this.paddingFocus = 10,
     this.colorShadow = Colors.black,
     this.opacityShadow = 0.8,
@@ -91,7 +93,7 @@ class AnimatedFocusLightState extends State<AnimatedFocusLight> with TickerProvi
   @override
   Widget build(BuildContext context) {
     return InkWell(
-      onTap: _targetFocus.enableOverlayTab ? next : null,
+      onTap: _targetFocus.enableOverlayTab ? () => _tapHandler(overlayTap: true) : null,
       child: AnimatedBuilder(
         animation: _controller,
         builder: (_, child) {
@@ -116,7 +118,7 @@ class AnimatedFocusLightState extends State<AnimatedFocusLight> with TickerProvi
                     top: (_targetPosition?.offset?.dy ?? 0) - _getPaddingFocus() * 2,
                     child: InkWell(
                       borderRadius: _betBorderRadiusTarget(),
-                      onTap: _targetFocus.enableTargetTab ? next : null,
+                      onTap: _targetFocus.enableTargetTab ? () => _tapHandler(targetTap: true) : null,
                       child: Container(
                         color: Colors.transparent,
                         width: (_targetPosition?.size?.width ?? 0) + _getPaddingFocus() * 4,
@@ -136,13 +138,18 @@ class AnimatedFocusLightState extends State<AnimatedFocusLight> with TickerProvi
   void next() => _tapHandler();
   void previous() => _tapHandler(goNext: false);
 
-  void _tapHandler({bool goNext = true}) {
+  void _tapHandler({bool goNext = true, bool targetTap = false, bool overlayTap = false}) {
     setState(() {
       _goNext = goNext;
       _initReverse = true;
     });
     _controllerPulse.reverse(from: _controllerPulse.value);
-    widget?.clickTarget(_targetFocus);
+    if (targetTap) {
+      widget?.clickTarget(_targetFocus);
+    }
+    if (overlayTap) {
+      widget?.clickOverlay(_targetFocus);
+    }
   }
 
   void _nextFocus() {

--- a/lib/tutorial_coach_mark.dart
+++ b/lib/tutorial_coach_mark.dart
@@ -11,6 +11,7 @@ class TutorialCoachMark {
   final BuildContext _context;
   final List<TargetFocus> targets;
   final Function(TargetFocus) onClickTarget;
+  final Function(TargetFocus) onClickOverlay;
   final Function() onFinish;
   final double paddingFocus;
   final Function() onClickSkip;
@@ -31,6 +32,7 @@ class TutorialCoachMark {
     this.targets,
     this.colorShadow = Colors.black,
     this.onClickTarget,
+    this.onClickOverlay,
     this.onFinish,
     this.paddingFocus = 10,
     this.onClickSkip,
@@ -50,6 +52,7 @@ class TutorialCoachMark {
           key: _widgetKey,
           targets: targets,
           clickTarget: onClickTarget,
+          clickOverlay: onClickOverlay,
           paddingFocus: paddingFocus,
           clickSkip: skip,
           alignSkip: alignSkip,

--- a/lib/tutorial_coach_mark_widget.dart
+++ b/lib/tutorial_coach_mark_widget.dart
@@ -12,6 +12,7 @@ class TutorialCoachMarkWidget extends StatefulWidget {
     this.finish,
     this.paddingFocus = 10,
     this.clickTarget,
+    this.clickOverlay,
     this.alignSkip = Alignment.bottomRight,
     this.textSkip = "SKIP",
     this.clickSkip,
@@ -25,6 +26,7 @@ class TutorialCoachMarkWidget extends StatefulWidget {
 
   final List<TargetFocus> targets;
   final Function(TargetFocus) clickTarget;
+  final Function(TargetFocus) clickOverlay;
   final Function() finish;
   final Color colorShadow;
   final double opacityShadow;
@@ -63,6 +65,9 @@ class TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget> {
             pulseAnimationDuration: widget.pulseAnimationDuration,
             clickTarget: (target) {
               if (widget.clickTarget != null) widget.clickTarget(target);
+            },
+            clickOverlay: (target) {
+              if (widget.clickOverlay != null) widget.clickOverlay(target);
             },
             focus: (target) {
               setState(() {


### PR DESCRIPTION
This PR resolves #28 

I added a callback `onClickOverlay` that is called when the overlay is clicked. Also, `onClickTarget` is now called only when the target is clicked.

My use case for this is that I have a `FloatingActionButton` that is the target. When the overlay is clicked, I just want to dismiss the tutorials. But when the target is clicked, I want to do the action in the `FloatingActionButton`'s `onPressed` method.