### PR TITLE
Allow to override `focusAnimationDuration` per target

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Attributes:
 | `enableTargetTab` | bool | enable click in target to call next step |
 | `alignSkip` | Alignment | use to align the skip in the target |
 | `paddingFocus` | Alignment | settings padding of the focus in target |
+| `focusAnimationDuration` | Duration | override the widget's global focus animation duration |
 
 ### Creating contents (ContentTarget)
 

--- a/lib/src/target/target_focus.dart
+++ b/lib/src/target/target_focus.dart
@@ -16,6 +16,7 @@ class TargetFocus {
     this.enableTargetTab = true,
     this.alignSkip,
     this.paddingFocus,
+    this.focusAnimationDuration,
   }) : assert(keyTarget != null || targetPosition != null);
 
   final dynamic identify;
@@ -29,6 +30,7 @@ class TargetFocus {
   final Color color;
   final AlignmentGeometry alignSkip;
   final double paddingFocus;
+  final Duration focusAnimationDuration;
 
   @override
   String toString() {

--- a/lib/src/widgets/animated_focus_light.dart
+++ b/lib/src/widgets/animated_focus_light.dart
@@ -40,6 +40,7 @@ class AnimatedFocusLight extends StatefulWidget {
 
 class AnimatedFocusLightState extends State<AnimatedFocusLight> with TickerProviderStateMixin {
   static const BORDER_RADIUS_DEFAULT = 10.0;
+  static const DEFAULT_FOCUS_ANIMATION_DURATION = Duration(milliseconds: 600);
   AnimationController _controller;
   AnimationController _controllerPulse;
   CurvedAnimation _curvedAnimation;
@@ -61,7 +62,7 @@ class AnimatedFocusLightState extends State<AnimatedFocusLight> with TickerProvi
     _targetFocus = widget?.targets[_currentFocus];
     _controller = AnimationController(
       vsync: this,
-      duration: widget.focusAnimationDuration ?? Duration(milliseconds: 600),
+      duration: _targetFocus?.focusAnimationDuration ?? widget.focusAnimationDuration ?? DEFAULT_FOCUS_ANIMATION_DURATION,
     );
 
     _curvedAnimation = CurvedAnimation(
@@ -156,6 +157,7 @@ class AnimatedFocusLightState extends State<AnimatedFocusLight> with TickerProvi
       return;
     }
     _currentFocus++;
+
     _runFocus();
   }
 
@@ -171,6 +173,8 @@ class AnimatedFocusLightState extends State<AnimatedFocusLight> with TickerProvi
   void _runFocus() {
     if (_currentFocus < 0) return;
     _targetFocus = widget.targets[_currentFocus];
+    _controller.duration = _targetFocus?.focusAnimationDuration ?? widget.focusAnimationDuration ?? DEFAULT_FOCUS_ANIMATION_DURATION;
+
     var targetPosition = getTargetCurrent(_targetFocus);
     if (targetPosition == null) {
       this._finish();


### PR DESCRIPTION
As title says. Concretely we use this to actually disable the animation for certain targets by setting it to `Duration.zero`, allowing us to create "in-between" targets that aren't actually focused on a given element.