### PR TITLE
Fixes undefined TargetPosition by exporting /src/target/target_position.dart

### DIFF
--- a/lib/tutorial_coach_mark.dart
+++ b/lib/tutorial_coach_mark.dart
@@ -6,6 +6,7 @@ import 'package:tutorial_coach_mark/src/widgets/tutorial_coach_mark_widget.dart'
 
 export 'package:tutorial_coach_mark/src/target/target_content.dart';
 export 'package:tutorial_coach_mark/src/target/target_focus.dart';
+export 'package:tutorial_coach_mark/src/target/target_position.dart';
 export 'package:tutorial_coach_mark/src/util.dart';
 
 class TutorialCoachMark {


### PR DESCRIPTION
export 'package:tutorial_coach_mark/src/target/target_position.dart';

closes #56 