### PR TITLE
Migrate to null safety

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -23,8 +23,8 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  TutorialCoachMark tutorialCoachMark;
-  List<TargetFocus> targets = List();
+  late TutorialCoachMark tutorialCoachMark;
+  List<TargetFocus> targets = <TargetFocus>[];
 
   GlobalKey keyButton = GlobalKey();
   GlobalKey keyButton1 = GlobalKey();

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,49 +7,49 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.1"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.3"
+    version: "1.15.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -66,21 +66,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.1"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.1"
+    version: "1.8.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -92,62 +92,62 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.1"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.2"
+    version: "0.2.19"
   tutorial_coach_mark:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "0.5.3"
+    version: "0.6.0+1"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.10.0-110 <2.11.0"
+  dart: ">=2.12.0 <3.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,7 +14,7 @@ description: A new Flutter application.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   flutter:

--- a/lib/src/paint/light_paint.dart
+++ b/lib/src/paint/light_paint.dart
@@ -7,7 +7,7 @@ class LightPaint extends CustomPainter {
   final Color colorShadow;
   final double opacityShadow;
 
-  Paint _paintFocus;
+  late Paint _paintFocus;
 
   LightPaint(
     this.progress,

--- a/lib/src/paint/light_paint_rect.dart
+++ b/lib/src/paint/light_paint_rect.dart
@@ -9,11 +9,11 @@ class LightPaintRect extends CustomPainter {
   final double offset;
   final double radius;
 
-  Paint _paintFocus;
+  late Paint _paintFocus;
 
   LightPaintRect({
-    this.progress,
-    this.target,
+    required this.progress,
+    required this.target,
     this.colorShadow = Colors.black,
     this.opacityShadow = 0.8,
     this.offset = 10,

--- a/lib/src/target/target_content.dart
+++ b/lib/src/target/target_content.dart
@@ -6,7 +6,7 @@ class CustomTargetContentPosition {
     this.left,
     this.bottom,
   });
-  final double top, left, bottom;
+  final double? top, left, bottom;
   @override
   String toString() {
     return 'CustomTargetPosition{top: $top, left: $left, bottom: $bottom}';
@@ -18,12 +18,12 @@ enum ContentAlign { top, bottom, left, right, custom }
 class TargetContent {
   TargetContent({
     this.align = ContentAlign.bottom,
-    this.child,
+    required this.child,
     this.customPosition,
-  }) : assert(child != null && !(align == ContentAlign.custom && customPosition == null));
+  }) : assert(!(align == ContentAlign.custom && customPosition == null));
 
   final ContentAlign align;
-  final CustomTargetContentPosition customPosition;
+  final CustomTargetContentPosition? customPosition;
   final Widget child;
   @override
   String toString() {

--- a/lib/src/target/target_focus.dart
+++ b/lib/src/target/target_focus.dart
@@ -19,16 +19,16 @@ class TargetFocus {
   }) : assert(keyTarget != null || targetPosition != null);
 
   final dynamic identify;
-  final GlobalKey keyTarget;
-  final TargetPosition targetPosition;
-  final List<TargetContent> contents;
-  final ShapeLightFocus shape;
-  final double radius;
+  final GlobalKey? keyTarget;
+  final TargetPosition? targetPosition;
+  final List<TargetContent>? contents;
+  final ShapeLightFocus? shape;
+  final double? radius;
   final bool enableOverlayTab;
   final bool enableTargetTab;
-  final Color color;
-  final AlignmentGeometry alignSkip;
-  final double paddingFocus;
+  final Color? color;
+  final AlignmentGeometry? alignSkip;
+  final double? paddingFocus;
 
   @override
   String toString() {

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -4,14 +4,14 @@ import 'package:tutorial_coach_mark/src/target/target_position.dart';
 
 enum ShapeLightFocus { Circle, RRect }
 
-TargetPosition getTargetCurrent(TargetFocus target) {
+TargetPosition? getTargetCurrent(TargetFocus target) {
   if (target.keyTarget != null) {
-    var key = target.keyTarget;
+    var key = target.keyTarget!;
 
     try {
-      final RenderBox renderBoxRed = key.currentContext.findRenderObject();
+      final RenderBox renderBoxRed = key.currentContext!.findRenderObject() as RenderBox;
       final size = renderBoxRed.size;
-      final state = key.currentContext.findAncestorStateOfType<NavigatorState>();
+      final state = key.currentContext!.findAncestorStateOfType<NavigatorState>();
       Offset offset;
       if (state != null) {
         offset = renderBoxRed.localToGlobal(Offset.zero, ancestor: state.context.findRenderObject());

--- a/lib/src/widgets/animated_focus_light.dart
+++ b/lib/src/widgets/animated_focus_light.dart
@@ -8,20 +8,20 @@ import 'package:tutorial_coach_mark/src/util.dart';
 
 class AnimatedFocusLight extends StatefulWidget {
   final List<TargetFocus> targets;
-  final Function(TargetFocus) focus;
-  final Function(TargetFocus) clickTarget;
-  final Function(TargetFocus) clickOverlay;
-  final Function removeFocus;
-  final Function() finish;
+  final Function(TargetFocus)? focus;
+  final Function(TargetFocus)? clickTarget;
+  final Function(TargetFocus)? clickOverlay;
+  final Function? removeFocus;
+  final Function()? finish;
   final double paddingFocus;
   final Color colorShadow;
   final double opacityShadow;
-  final Duration focusAnimationDuration;
-  final Duration pulseAnimationDuration;
+  final Duration? focusAnimationDuration;
+  final Duration? pulseAnimationDuration;
 
   const AnimatedFocusLight({
-    Key key,
-    this.targets,
+    Key? key,
+    required this.targets,
     this.focus,
     this.finish,
     this.removeFocus,
@@ -40,25 +40,25 @@ class AnimatedFocusLight extends StatefulWidget {
 
 class AnimatedFocusLightState extends State<AnimatedFocusLight> with TickerProviderStateMixin {
   static const BORDER_RADIUS_DEFAULT = 10.0;
-  AnimationController _controller;
-  AnimationController _controllerPulse;
-  CurvedAnimation _curvedAnimation;
-  Animation _tweenPulse;
+  late AnimationController _controller;
+  late AnimationController _controllerPulse;
+  late CurvedAnimation _curvedAnimation;
+  late Animation _tweenPulse;
   Offset _positioned = Offset(0.0, 0.0);
-  TargetPosition _targetPosition;
+  TargetPosition? _targetPosition;
 
   double _sizeCircle = 100;
   int _currentFocus = 0;
   bool _finishFocus = false;
   bool _initReverse = false;
   double _progressAnimated = 0;
-  TargetFocus _targetFocus;
+  TargetFocus? _targetFocus;
 
   bool _goNext = true;
 
   @override
   void initState() {
-    _targetFocus = widget?.targets[_currentFocus];
+    _targetFocus = widget.targets[_currentFocus];
     _controller = AnimationController(
       vsync: this,
       duration: widget.focusAnimationDuration ?? Duration(milliseconds: 600),
@@ -84,14 +84,14 @@ class AnimatedFocusLightState extends State<AnimatedFocusLight> with TickerProvi
     _controller.addStatusListener(_listener);
     _controllerPulse.addStatusListener(_listenerPulse);
 
-    WidgetsBinding.instance.addPostFrameCallback((_) => _runFocus());
+    WidgetsBinding.instance!.addPostFrameCallback((_) => _runFocus());
     super.initState();
   }
 
   @override
   Widget build(BuildContext context) {
     return InkWell(
-      onTap: _targetFocus.enableOverlayTab ? () => _tapHandler(overlayTap: true) : null,
+      onTap: _targetFocus!.enableOverlayTab ? () => _tapHandler(overlayTap: true) : null,
       child: AnimatedBuilder(
         animation: _controller,
         builder: (_, child) {
@@ -112,15 +112,15 @@ class AnimatedFocusLightState extends State<AnimatedFocusLight> with TickerProvi
                     ),
                   ),
                   Positioned(
-                    left: (_targetPosition?.offset?.dx ?? 0) - _getPaddingFocus() * 2,
-                    top: (_targetPosition?.offset?.dy ?? 0) - _getPaddingFocus() * 2,
+                    left: (_targetPosition?.offset.dx ?? 0) - _getPaddingFocus() * 2,
+                    top: (_targetPosition?.offset.dy ?? 0) - _getPaddingFocus() * 2,
                     child: InkWell(
                       borderRadius: _betBorderRadiusTarget(),
-                      onTap: _targetFocus.enableTargetTab ? () => _tapHandler(targetTap: true) : null,
+                      onTap: _targetFocus!.enableTargetTab ? () => _tapHandler(targetTap: true) : null,
                       child: Container(
                         color: Colors.transparent,
-                        width: (_targetPosition?.size?.width ?? 0) + _getPaddingFocus() * 4,
-                        height: (_targetPosition?.size?.height ?? 0) + _getPaddingFocus() * 4,
+                        width: (_targetPosition?.size.width ?? 0) + _getPaddingFocus() * 4,
+                        height: (_targetPosition?.size.height ?? 0) + _getPaddingFocus() * 4,
                       ),
                     ),
                   )
@@ -142,11 +142,11 @@ class AnimatedFocusLightState extends State<AnimatedFocusLight> with TickerProvi
       _initReverse = true;
     });
     _controllerPulse.reverse(from: _controllerPulse.value);
-    if (targetTap) {
-      widget?.clickTarget(_targetFocus);
+    if (targetTap && _targetFocus != null) {
+      widget.clickTarget?.call(_targetFocus!);
     }
-    if (overlayTap) {
-      widget?.clickOverlay(_targetFocus);
+    if (overlayTap && _targetFocus != null) {
+      widget.clickOverlay?.call(_targetFocus!);
     }
   }
 
@@ -171,7 +171,7 @@ class AnimatedFocusLightState extends State<AnimatedFocusLight> with TickerProvi
   void _runFocus() {
     if (_currentFocus < 0) return;
     _targetFocus = widget.targets[_currentFocus];
-    var targetPosition = getTargetCurrent(_targetFocus);
+    var targetPosition = getTargetCurrent(_targetFocus!);
     if (targetPosition == null) {
       this._finish();
       return;
@@ -200,7 +200,7 @@ class AnimatedFocusLightState extends State<AnimatedFocusLight> with TickerProvi
     setState(() {
       _currentFocus = 0;
     });
-    widget.finish();
+    widget.finish!();
   }
 
   @override
@@ -232,7 +232,9 @@ class AnimatedFocusLightState extends State<AnimatedFocusLight> with TickerProvi
       setState(() {
         _finishFocus = true;
       });
-      widget?.focus(_targetFocus);
+      if (_targetFocus != null) {
+        widget.focus?.call(_targetFocus!);
+      }
 
       _controllerPulse.forward();
     }
@@ -249,11 +251,11 @@ class AnimatedFocusLightState extends State<AnimatedFocusLight> with TickerProvi
     }
 
     if (status == AnimationStatus.reverse) {
-      widget?.removeFocus();
+      widget.removeFocus!();
     }
   }
 
-  CustomPainter _getPainter(TargetFocus target) {
+  CustomPainter _getPainter(TargetFocus? target) {
     if (target?.shape == ShapeLightFocus.RRect) {
       return LightPaintRect(
         colorShadow: target?.color ?? widget.colorShadow,
@@ -275,12 +277,12 @@ class AnimatedFocusLightState extends State<AnimatedFocusLight> with TickerProvi
   }
 
   double _getPaddingFocus() {
-    return _targetFocus?.paddingFocus ?? (widget.paddingFocus ?? 10);
+    return _targetFocus?.paddingFocus ?? (widget.paddingFocus);
   }
 
   BorderRadius _betBorderRadiusTarget() {
     double radius = _targetFocus?.shape == ShapeLightFocus.Circle
-        ? (_targetPosition?.size?.width ?? BORDER_RADIUS_DEFAULT)
+        ? (_targetPosition?.size.width ?? BORDER_RADIUS_DEFAULT)
         : _targetFocus?.radius ?? BORDER_RADIUS_DEFAULT;
     return BorderRadius.circular(radius);
   }

--- a/lib/src/widgets/tutorial_coach_mark_widget.dart
+++ b/lib/src/widgets/tutorial_coach_mark_widget.dart
@@ -99,7 +99,10 @@ class TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget> {
 
     List<Widget> children = <Widget>[];
 
-    TargetPosition target = getTargetCurrent(currentTarget!)!;
+    final target = getTargetCurrent(currentTarget!);
+    if (target == null) {
+      return SizedBox.shrink();
+    }
 
     var positioned = Offset(
       target.offset.dx + target.size.width / 2,

--- a/lib/src/widgets/tutorial_coach_mark_widget.dart
+++ b/lib/src/widgets/tutorial_coach_mark_widget.dart
@@ -7,8 +7,8 @@ import 'package:tutorial_coach_mark/src/widgets/animated_focus_light.dart';
 
 class TutorialCoachMarkWidget extends StatefulWidget {
   const TutorialCoachMarkWidget({
-    Key key,
-    this.targets,
+    Key? key,
+    required this.targets,
     this.finish,
     this.paddingFocus = 10,
     this.clickTarget,
@@ -25,19 +25,19 @@ class TutorialCoachMarkWidget extends StatefulWidget {
   }) : super(key: key);
 
   final List<TargetFocus> targets;
-  final Function(TargetFocus) clickTarget;
-  final Function(TargetFocus) clickOverlay;
-  final Function() finish;
+  final Function(TargetFocus)? clickTarget;
+  final Function(TargetFocus)? clickOverlay;
+  final Function()? finish;
   final Color colorShadow;
   final double opacityShadow;
   final double paddingFocus;
-  final Function() onClickSkip;
+  final Function()? onClickSkip;
   final AlignmentGeometry alignSkip;
   final String textSkip;
   final TextStyle textStyleSkip;
-  final bool hideSkip;
-  final Duration focusAnimationDuration;
-  final Duration pulseAnimationDuration;
+  final bool? hideSkip;
+  final Duration? focusAnimationDuration;
+  final Duration? pulseAnimationDuration;
 
   @override
   TutorialCoachMarkWidgetState createState() => TutorialCoachMarkWidgetState();
@@ -46,7 +46,7 @@ class TutorialCoachMarkWidget extends StatefulWidget {
 class TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget> {
   final GlobalKey<AnimatedFocusLightState> _focusLightKey = GlobalKey();
   bool showContent = false;
-  TargetFocus currentTarget;
+  TargetFocus? currentTarget;
 
   @override
   Widget build(BuildContext context) {
@@ -97,9 +97,9 @@ class TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget> {
       return SizedBox.shrink();
     }
 
-    List<Widget> children = List();
+    List<Widget> children = <Widget>[];
 
-    TargetPosition target = getTargetCurrent(currentTarget);
+    TargetPosition target = getTargetCurrent(currentTarget!)!;
 
     var positioned = Offset(
       target.offset.dx + target.size.width / 2,
@@ -109,7 +109,7 @@ class TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget> {
     double haloWidth;
     double haloHeight;
 
-    if (currentTarget.shape == ShapeLightFocus.Circle) {
+    if (currentTarget!.shape == ShapeLightFocus.Circle) {
       haloWidth = target.size.width > target.size.height ? target.size.width : target.size.height;
       haloHeight = haloWidth;
     } else {
@@ -121,11 +121,11 @@ class TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget> {
     haloHeight = haloHeight * 0.6 + widget.paddingFocus;
 
     double weight = 0.0;
-    double top;
-    double bottom;
-    double left;
+    double? top;
+    double? bottom;
+    double? left;
 
-    children = currentTarget.contents.map<Widget>((i) {
+    children = currentTarget!.contents!.map<Widget>((i) {
       switch (i.align) {
         case ContentAlign.bottom:
           {
@@ -156,14 +156,14 @@ class TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget> {
             left = positioned.dx + haloWidth;
             top = positioned.dy - target.size.height / 2 - haloHeight;
             bottom = null;
-            weight = MediaQuery.of(context).size.width - left;
+            weight = MediaQuery.of(context).size.width - left!;
           }
           break;
         case ContentAlign.custom:
           {
-            left = i.customPosition.left;
-            top = i.customPosition.top;
-            bottom = i.customPosition.bottom;
+            left = i.customPosition!.left;
+            top = i.customPosition!.top;
+            bottom = i.customPosition!.bottom;
             weight = MediaQuery.of(context).size.width;
           }
           break;
@@ -189,7 +189,7 @@ class TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget> {
   }
 
   Widget _buildSkip() {
-    if (widget.hideSkip) {
+    if (widget.hideSkip!) {
       return SizedBox.shrink();
     }
     return Align(
@@ -213,6 +213,6 @@ class TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget> {
     );
   }
 
-  void next() => _focusLightKey?.currentState?.next();
-  void previous() => _focusLightKey?.currentState?.previous();
+  void next() => _focusLightKey.currentState?.next();
+  void previous() => _focusLightKey.currentState?.previous();
 }

--- a/lib/tutorial_coach_mark.dart
+++ b/lib/tutorial_coach_mark.dart
@@ -11,11 +11,11 @@ export 'package:tutorial_coach_mark/src/util.dart';
 class TutorialCoachMark {
   final BuildContext _context;
   final List<TargetFocus> targets;
-  final Function(TargetFocus) onClickTarget;
-  final Function(TargetFocus) onClickOverlay;
-  final Function() onFinish;
+  final Function(TargetFocus)? onClickTarget;
+  final Function(TargetFocus)? onClickOverlay;
+  final Function()? onFinish;
   final double paddingFocus;
-  final Function() onSkip;
+  final Function()? onSkip;
   final AlignmentGeometry alignSkip;
   final String textSkip;
   final TextStyle textStyleSkip;
@@ -26,11 +26,11 @@ class TutorialCoachMark {
   final Duration focusAnimationDuration;
   final Duration pulseAnimationDuration;
 
-  OverlayEntry _overlayEntry;
+  OverlayEntry? _overlayEntry;
 
   TutorialCoachMark(
     this._context, {
-    this.targets,
+    required this.targets,
     this.colorShadow = Colors.black,
     this.onClickTarget,
     this.onClickOverlay,
@@ -71,11 +71,11 @@ class TutorialCoachMark {
   }
 
   void show() {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    WidgetsBinding.instance!.addPostFrameCallback((_) {
       Future.delayed(Duration.zero, () {
         if (_overlayEntry == null) {
           _overlayEntry = _buildOverlay();
-          Overlay.of(_context).insert(_overlayEntry);
+          Overlay.of(_context)!.insert(_overlayEntry!);
         }
       });
     });

--- a/lib/tutorial_coach_mark.dart
+++ b/lib/tutorial_coach_mark.dart
@@ -93,8 +93,8 @@ class TutorialCoachMark {
 
   bool get isShowing => _overlayEntry != null;
 
-  void next() => _widgetKey?.currentState?.next();
-  void previous() => _widgetKey?.currentState?.previous();
+  void next() => _widgetKey.currentState?.next();
+  void previous() => _widgetKey.currentState?.previous();
 
   void _removeOverlay() {
     _overlayEntry?.remove();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,49 +7,49 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.2"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.2"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.4"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.2"
+    version: "1.2.0"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.2"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.4"
+    version: "1.15.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.2"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -66,21 +66,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.2"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.5"
+    version: "1.3.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -92,55 +92,55 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.3"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.5"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.2"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.2"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.2"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.4"
+    version: "0.2.19"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.4"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.4"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.11.0-0.0 <2.12.0"
+  dart: ">=2.12.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.6.0+1
 homepage: https://github.com/RafaelBarbosatec/tutorial_coach_mark
 
 environment:
-  sdk: ">=2.6.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
This PR migrates the library to null safety. I tried the other branch from PR #50 and encountered some crashes. No crashes so far with this branch. I used the `dart migrate` tool to migrate to null safety and added `required` to several params. The example works too. 