### PR TITLE
Add support for web

### DIFF
--- a/lib/src/paint/light_paint.dart
+++ b/lib/src/paint/light_paint.dart
@@ -9,31 +9,41 @@ class LightPaint extends CustomPainter {
   final Color colorShadow;
   final double opacityShadow;
 
-  late Paint _paintFocus;
-
   LightPaint(
     this.progress,
     this.positioned,
     this.sizeCircle, {
     this.colorShadow = Colors.black,
     this.opacityShadow = 0.8,
-  }) : assert(opacityShadow >= 0 && opacityShadow <= 1) {
-    _paintFocus = Paint()
-      ..color = Colors.transparent
-      ..blendMode = BlendMode.clear;
-  }
+  }) : assert(opacityShadow >= 0 && opacityShadow <= 1);
 
   @override
   void paint(Canvas canvas, Size size) {
-    canvas.saveLayer(Offset.zero & size, Paint());
-    canvas.drawColor(colorShadow.withOpacity(opacityShadow), BlendMode.dstATop);
-
     var maxSize = max(size.width, size.height);
 
     double radius = maxSize * (1 - progress) + sizeCircle;
 
-    canvas.drawCircle(positioned, radius, _paintFocus);
-    canvas.restore();
+    final circleHole = Path()
+      ..moveTo(0, 0)
+      ..lineTo(0, positioned.dy)
+      ..arcTo(
+        Rect.fromCircle(center: positioned, radius: radius),
+        pi,
+        2 * pi,
+        false,
+      )
+      ..lineTo(0, positioned.dy)
+      ..lineTo(0, size.height)
+      ..lineTo(size.width, size.height)
+      ..lineTo(size.width, 0)
+      ..close();
+
+    canvas.drawPath(
+      circleHole,
+      Paint()
+        ..style = PaintingStyle.fill
+        ..color = colorShadow.withOpacity(opacityShadow),
+    );
   }
 
   @override

--- a/lib/src/paint/light_paint.dart
+++ b/lib/src/paint/light_paint.dart
@@ -23,13 +23,23 @@ class LightPaint extends CustomPainter {
 
     double radius = maxSize * (1 - progress) + sizeCircle;
 
+    // There is some weirdness here.  On mobile, using arcTo with `sweepAngle: 2 * pi`
+    // gives the equivalent of `sweepAngle: 0`.  I couldn't find any documentation
+    // of the expected behavior here, so instead I just call arcTo twice (two
+    // semi-circles) to outline the full hole.
     final circleHole = Path()
       ..moveTo(0, 0)
       ..lineTo(0, positioned.dy)
       ..arcTo(
         Rect.fromCircle(center: positioned, radius: radius),
         pi,
-        2 * pi,
+        pi,
+        false,
+      )
+      ..arcTo(
+        Rect.fromCircle(center: positioned, radius: radius),
+        0,
+        pi,
         false,
       )
       ..lineTo(0, positioned.dy)

--- a/lib/src/paint/light_paint_rect.dart
+++ b/lib/src/paint/light_paint_rect.dart
@@ -50,35 +50,37 @@ class LightPaintRect extends CustomPainter {
     double h,
     double radius,
   ) {
+    double diameter = radius * 2;
+
     return Path()
       ..moveTo(0, 0)
-      ..lineTo(0, y + radius / 2)
+      ..lineTo(0, y + radius)
       ..arcTo(
-        Rect.fromLTWH(x, y, radius, radius),
+        Rect.fromLTWH(x, y, diameter, diameter),
         pi,
         pi / 2,
         false,
       )
       ..arcTo(
-        Rect.fromLTWH(x + w - radius, y, radius, radius),
+        Rect.fromLTWH(x + w - diameter, y, diameter, diameter),
         3 * pi / 2,
         pi / 2,
         false,
       )
       ..arcTo(
-        Rect.fromLTWH(x + w - radius, y + h - radius, radius, radius),
+        Rect.fromLTWH(x + w - diameter, y + h - diameter, diameter, diameter),
         0,
         pi / 2,
         false,
       )
       ..arcTo(
-        Rect.fromLTWH(x, y + h - radius, radius, radius),
+        Rect.fromLTWH(x, y + h - diameter, diameter, diameter),
         pi / 2,
         pi / 2,
         false,
       )
-      ..lineTo(x, y + radius / 2)
-      ..lineTo(0, y + radius / 2)
+      ..lineTo(x, y + radius)
+      ..lineTo(0, y + radius)
       ..lineTo(0, canvasSize.height)
       ..lineTo(canvasSize.width, canvasSize.height)
       ..lineTo(canvasSize.width, 0)

--- a/lib/src/paint/light_paint_rect.dart
+++ b/lib/src/paint/light_paint_rect.dart
@@ -12,8 +12,6 @@ class LightPaintRect extends CustomPainter {
   final double offset;
   final double radius;
 
-  late Paint _paintFocus;
-
   LightPaintRect({
     required this.progress,
     required this.target,
@@ -21,17 +19,75 @@ class LightPaintRect extends CustomPainter {
     this.opacityShadow = 0.8,
     this.offset = 10,
     this.radius = 10,
-  }) : assert(opacityShadow >= 0 && opacityShadow <= 1) {
-    _paintFocus = Paint()
-      ..color = Colors.transparent
-      ..blendMode = BlendMode.clear;
+  }) : assert(opacityShadow >= 0 && opacityShadow <= 1);
+
+  static Path _drawRectHole(
+    Size canvasSize,
+    double x,
+    double y,
+    double w,
+    double h,
+  ) {
+    return Path()
+      ..moveTo(0, 0)
+      ..lineTo(0, y)
+      ..lineTo(x + w, y)
+      ..lineTo(x + w, y + h)
+      ..lineTo(x, y + h)
+      ..lineTo(x, y)
+      ..lineTo(0, y)
+      ..lineTo(0, canvasSize.height)
+      ..lineTo(canvasSize.width, canvasSize.height)
+      ..lineTo(canvasSize.width, 0)
+      ..close();
+  }
+
+  static Path _drawRRectHole(
+    Size canvasSize,
+    double x,
+    double y,
+    double w,
+    double h,
+    double radius,
+  ) {
+    return Path()
+      ..moveTo(0, 0)
+      ..lineTo(0, y + radius / 2)
+      ..arcTo(
+        Rect.fromLTWH(x, y, radius, radius),
+        pi,
+        pi / 2,
+        false,
+      )
+      ..arcTo(
+        Rect.fromLTWH(x + w - radius, y, radius, radius),
+        3 * pi / 2,
+        pi / 2,
+        false,
+      )
+      ..arcTo(
+        Rect.fromLTWH(x + w - radius, y + h - radius, radius, radius),
+        0,
+        pi / 2,
+        false,
+      )
+      ..arcTo(
+        Rect.fromLTWH(x, y + h - radius, radius, radius),
+        pi / 2,
+        pi / 2,
+        false,
+      )
+      ..lineTo(x, y + radius / 2)
+      ..lineTo(0, y + radius / 2)
+      ..lineTo(0, canvasSize.height)
+      ..lineTo(canvasSize.width, canvasSize.height)
+      ..lineTo(canvasSize.width, 0)
+      ..close();
   }
 
   @override
   void paint(Canvas canvas, Size size) {
     if (target.offset == Offset.zero) return;
-    canvas.saveLayer(Offset.zero & size, Paint());
-    canvas.drawColor(colorShadow.withOpacity(opacityShadow), BlendMode.dstATop);
 
     var maxSize = max(size.width, size.height) +
         max(target.size.width, target.size.height);
@@ -44,12 +100,14 @@ class LightPaintRect extends CustomPainter {
 
     double h = maxSize * (1 - progress) + target.size.height + offset;
 
-    RRect rrect = RRect.fromRectAndRadius(
-      Rect.fromLTWH(x, y, w, h),
-      Radius.circular(radius),
+    canvas.drawPath(
+      radius > 0
+          ? _drawRRectHole(size, x, y, w, h, radius)
+          : _drawRectHole(size, x, y, w, h),
+      Paint()
+        ..style = PaintingStyle.fill
+        ..color = colorShadow.withOpacity(opacityShadow),
     );
-    canvas.drawRRect(rrect, _paintFocus);
-    canvas.restore();
   }
 
   @override


### PR DESCRIPTION
Flutter does not currently support either:
- `BlendMode.clear`
- `Path.combine`

To work around this, I swapped out the layered approach in the current repo with an approach which simply draws the inverted shape (either a circle, rectangle, or rounded rectangle) used for the overlay.

It would be nice if Flutter Web supported the above listed method.  But they don't and I need this now, so I thought I'd open a PR if you're interested.  It ain't pretty, but it works.

Cheers.