### PR TITLE
Adds the option to customize the content's padding.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Attributes:
 | Attribute | Type | Description |
 | --- | --- | --- |
 | `align` | AlignContent | With this attribute you determine in which region to display the content in relation to the focused widget (top,bottom,left,right) |
+| `padding` | EdgeInsets | Padding of the content |
 | `child` | Widget | Content you want to be displayed |
 | `builder` | Widget | Content you want to be displayed |
 | `customPosition` | CustomTargetContentPosition | Add custom position when `align` is AlignContent.custom |

--- a/lib/src/target/target_content.dart
+++ b/lib/src/target/target_content.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
 import '../../tutorial_coach_mark.dart';
@@ -25,12 +26,14 @@ typedef TargetContentBuilder = Widget Function(
 class TargetContent {
   TargetContent({
     this.align = ContentAlign.bottom,
+    this.padding = const EdgeInsets.all(20.0),
     this.child,
     this.customPosition,
     this.builder,
   }) : assert(!(align == ContentAlign.custom && customPosition == null));
 
   final ContentAlign align;
+  final EdgeInsets padding;
   final CustomTargetContentPosition? customPosition;
   final Widget? child;
   final TargetContentBuilder? builder;

--- a/lib/src/widgets/tutorial_coach_mark_widget.dart
+++ b/lib/src/widgets/tutorial_coach_mark_widget.dart
@@ -188,7 +188,7 @@ class TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget>
         child: Container(
           width: weight,
           child: Padding(
-            padding: const EdgeInsets.all(20.0),
+            padding: i.padding,
             child: i.builder != null
                 ? i.builder?.call(context, this)
                 : (i.child ?? SizedBox.shrink()),


### PR DESCRIPTION
This PR adds the option to customize the content's padding by adding a `padding` variable to the `TargetContent` class. I kept the default padding as `EdgeInsets.all(20.0)` to avoid any surprise when updating to the new version.