### PR TITLE
Add the option to enable/disable pulse animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Attributes:
 | `paddingFocus` | Alignment | settings padding of the focus in target |
 | `focusAnimationDuration` | Duration | override the widget's global focus animation duration |
 | `pulseVariation` | Tween | override interval pulse animation |
+| `pulseEnable` | bool | enable/disable pulse animation |
 
 ### Creating contents (ContentTarget)
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Attributes:
 | `paddingFocus` | Alignment | settings padding of the focus in target |
 | `focusAnimationDuration` | Duration | override the widget's global focus animation duration |
 | `pulseVariation` | Tween | override interval pulse animation |
-| `pulseEnable` | bool | enable/disable pulse animation |
 
 ### Creating contents (ContentTarget)
 

--- a/lib/src/widgets/animated_focus_light.dart
+++ b/lib/src/widgets/animated_focus_light.dart
@@ -49,46 +49,243 @@ abstract class AnimatedFocusLightState extends State<AnimatedFocusLight>
     with TickerProviderStateMixin {
   final borderRadiusDefault = 10.0;
   final defaultFocusAnimationDuration = Duration(milliseconds: 600);
-
-  void next();
-
-  void previous();
-}
-
-class AnimatedPulseFocusLightState extends AnimatedFocusLightState {
-  final defaultPulseAnimationDuration = Duration(milliseconds: 500);
-  final defaultPulseVariation = Tween(begin: 1.0, end: 0.99);
   late AnimationController _controller;
-  late AnimationController _controllerPulse;
   late CurvedAnimation _curvedAnimation;
-  late Animation _tweenPulse;
+
   late TargetFocus _targetFocus;
   Offset _positioned = Offset(0.0, 0.0);
   TargetPosition? _targetPosition;
 
   double _sizeCircle = 100;
   int _currentFocus = 0;
-  bool _finishFocus = false;
-  bool _initReverse = false;
   double _progressAnimated = 0;
-
   bool _goNext = true;
 
   @override
   void initState() {
+    super.initState();
     _targetFocus = widget.targets[_currentFocus];
     _controller = AnimationController(
       vsync: this,
       duration: _targetFocus.focusAnimationDuration ??
           widget.focusAnimationDuration ??
           defaultFocusAnimationDuration,
-    );
+    )..addStatusListener(_listener);
 
     _curvedAnimation = CurvedAnimation(
       parent: _controller,
       curve: Curves.ease,
     );
 
+    WidgetsBinding.instance?.addPostFrameCallback((_) => _runFocus());
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void next() => _tapHandler();
+
+  void previous() => _tapHandler(goNext: false);
+
+  void _tapHandler({
+    bool goNext = true,
+    bool targetTap = false,
+    bool overlayTap = false,
+  }) {
+    if (targetTap) {
+      widget.clickTarget?.call(_targetFocus);
+    }
+    if (overlayTap) {
+      widget.clickOverlay?.call(_targetFocus);
+    }
+  }
+
+  void _runFocus();
+
+  void _nextFocus() {
+    if (_currentFocus >= widget.targets.length - 1) {
+      _finish();
+      return;
+    }
+    _currentFocus++;
+
+    _runFocus();
+  }
+
+  void _previousFocus() {
+    if (_currentFocus <= 0) {
+      _finish();
+      return;
+    }
+    _currentFocus--;
+    _runFocus();
+  }
+
+  void _finish() {
+    setState(() => _currentFocus = 0);
+    widget.finish!();
+  }
+
+  void _listener(AnimationStatus status);
+
+  CustomPainter _getPainter(TargetFocus? target) {
+    if (target?.shape == ShapeLightFocus.RRect) {
+      return LightPaintRect(
+        colorShadow: target?.color ?? widget.colorShadow,
+        progress: _progressAnimated,
+        offset: _getPaddingFocus(),
+        target: _targetPosition ?? TargetPosition(Size.zero, Offset.zero),
+        radius: target?.radius ?? 0,
+        opacityShadow: widget.opacityShadow,
+      );
+    } else {
+      return LightPaint(
+        _progressAnimated,
+        _positioned,
+        _sizeCircle,
+        colorShadow: target?.color ?? widget.colorShadow,
+        opacityShadow: widget.opacityShadow,
+      );
+    }
+  }
+
+  double _getPaddingFocus() {
+    return _targetFocus.paddingFocus ?? (widget.paddingFocus);
+  }
+
+  BorderRadius _betBorderRadiusTarget() {
+    double radius = _targetFocus.shape == ShapeLightFocus.Circle
+        ? _targetPosition?.size.width ?? borderRadiusDefault
+        : _targetFocus.radius ?? borderRadiusDefault;
+    return BorderRadius.circular(radius);
+  }
+}
+
+class AnimatedStaticFocusLightState extends AnimatedFocusLightState {
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: _targetFocus.enableOverlayTab
+          ? () => _tapHandler(overlayTap: true)
+          : null,
+      child: AnimatedBuilder(
+        animation: _controller,
+        builder: (_, child) {
+          _progressAnimated = _curvedAnimation.value;
+          return Stack(
+            children: <Widget>[
+              Container(
+                width: double.maxFinite,
+                height: double.maxFinite,
+                child: CustomPaint(
+                  painter: _getPainter(_targetFocus),
+                ),
+              ),
+              Positioned(
+                left:
+                    (_targetPosition?.offset.dx ?? 0) - _getPaddingFocus() * 2,
+                top: (_targetPosition?.offset.dy ?? 0) - _getPaddingFocus() * 2,
+                child: InkWell(
+                  borderRadius: _betBorderRadiusTarget(),
+                  onTap: _targetFocus.enableTargetTab
+                      ? () => _tapHandler(targetTap: true)
+                      : null,
+                  child: Container(
+                    color: Colors.transparent,
+                    width: (_targetPosition?.size.width ?? 0) +
+                        _getPaddingFocus() * 4,
+                    height: (_targetPosition?.size.height ?? 0) +
+                        _getPaddingFocus() * 4,
+                  ),
+                ),
+              )
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  @override
+  void _tapHandler({
+    bool goNext = true,
+    bool targetTap = false,
+    bool overlayTap = false,
+  }) {
+    super._tapHandler(
+        goNext: goNext, targetTap: targetTap, overlayTap: overlayTap);
+    setState(() => _goNext = goNext);
+    _controller.reverse();
+  }
+
+  @override
+  void _runFocus() {
+    if (_currentFocus < 0) return;
+    _targetFocus = widget.targets[_currentFocus];
+
+    _controller.duration = _targetFocus.focusAnimationDuration ??
+        widget.focusAnimationDuration ??
+        defaultFocusAnimationDuration;
+
+    var targetPosition = getTargetCurrent(_targetFocus);
+
+    if (targetPosition == null) {
+      _finish();
+      return;
+    }
+
+    setState(() {
+      _targetPosition = targetPosition;
+
+      _positioned = Offset(
+        targetPosition.offset.dx + (targetPosition.size.width / 2),
+        targetPosition.offset.dy + (targetPosition.size.height / 2),
+      );
+
+      if (targetPosition.size.height > targetPosition.size.width) {
+        _sizeCircle = targetPosition.size.height * 0.6 + _getPaddingFocus();
+      } else {
+        _sizeCircle = targetPosition.size.width * 0.6 + _getPaddingFocus();
+      }
+    });
+
+    _controller.forward();
+  }
+
+  @override
+  void _listener(AnimationStatus status) {
+    if (status == AnimationStatus.completed) {
+      widget.focus?.call(_targetFocus);
+    }
+    if (status == AnimationStatus.dismissed) {
+      if (_goNext) {
+        _nextFocus();
+      } else {
+        _previousFocus();
+      }
+    }
+
+    if (status == AnimationStatus.reverse) {
+      widget.removeFocus!();
+    }
+  }
+}
+
+class AnimatedPulseFocusLightState extends AnimatedFocusLightState {
+  final defaultPulseAnimationDuration = Duration(milliseconds: 500);
+  final defaultPulseVariation = Tween(begin: 1.0, end: 0.99);
+  late AnimationController _controllerPulse;
+  late Animation _tweenPulse;
+
+  bool _finishFocus = false;
+  bool _initReverse = false;
+
+  @override
+  void initState() {
+    super.initState();
     _controllerPulse = AnimationController(
       vsync: this,
       duration: widget.pulseAnimationDuration ?? defaultPulseAnimationDuration,
@@ -98,11 +295,7 @@ class AnimatedPulseFocusLightState extends AnimatedFocusLightState {
         widget.pulseVariation ??
         defaultPulseVariation);
 
-    _controller.addStatusListener(_listener);
     _controllerPulse.addStatusListener(_listenerPulse);
-
-    WidgetsBinding.instance?.addPostFrameCallback((_) => _runFocus());
-    super.initState();
   }
 
   @override
@@ -159,45 +352,6 @@ class AnimatedPulseFocusLightState extends AnimatedFocusLightState {
   }
 
   @override
-  void next() => _tapHandler();
-
-  @override
-  void previous() => _tapHandler(goNext: false);
-
-  void _tapHandler(
-      {bool goNext = true, bool targetTap = false, bool overlayTap = false}) {
-    setState(() {
-      _goNext = goNext;
-      _initReverse = true;
-    });
-    _controllerPulse.reverse(from: _controllerPulse.value);
-    if (targetTap) {
-      widget.clickTarget?.call(_targetFocus);
-    }
-    if (overlayTap) {
-      widget.clickOverlay?.call(_targetFocus);
-    }
-  }
-
-  void _nextFocus() {
-    if (_currentFocus >= widget.targets.length - 1) {
-      this._finish();
-      return;
-    }
-    _currentFocus++;
-
-    _runFocus();
-  }
-
-  void _previousFocus() {
-    if (_currentFocus <= 0) {
-      this._finish();
-      return;
-    }
-    _currentFocus--;
-    _runFocus();
-  }
-
   void _runFocus() {
     if (_currentFocus < 0) return;
     _targetFocus = widget.targets[_currentFocus];
@@ -213,13 +367,13 @@ class AnimatedPulseFocusLightState extends AnimatedFocusLightState {
     var targetPosition = getTargetCurrent(_targetFocus);
 
     if (targetPosition == null) {
-      this._finish();
+      _finish();
       return;
     }
 
     setState(() {
       _finishFocus = false;
-      this._targetPosition = targetPosition;
+      _targetPosition = targetPosition;
 
       _positioned = Offset(
         targetPosition.offset.dx + (targetPosition.size.width / 2),
@@ -236,42 +390,31 @@ class AnimatedPulseFocusLightState extends AnimatedFocusLightState {
     _controller.forward();
   }
 
-  void _finish() {
+  @override
+  void _tapHandler({
+    bool goNext = true,
+    bool targetTap = false,
+    bool overlayTap = false,
+  }) {
+    super._tapHandler(
+        goNext: goNext, targetTap: targetTap, overlayTap: overlayTap);
     setState(() {
-      _currentFocus = 0;
+      _goNext = goNext;
+      _initReverse = true;
     });
-    widget.finish!();
+    _controllerPulse.reverse(from: _controllerPulse.value);
   }
 
   @override
   void dispose() {
     _controllerPulse.dispose();
-    _controller.dispose();
     super.dispose();
   }
 
-  void _listenerPulse(AnimationStatus status) {
-    if (status == AnimationStatus.completed) {
-      _controllerPulse.reverse();
-    }
-
-    if (status == AnimationStatus.dismissed) {
-      if (_initReverse) {
-        setState(() {
-          _finishFocus = false;
-        });
-        _controller.reverse();
-      } else if (_finishFocus) {
-        _controllerPulse.forward();
-      }
-    }
-  }
-
+  @override
   void _listener(AnimationStatus status) {
     if (status == AnimationStatus.completed) {
-      setState(() {
-        _finishFocus = true;
-      });
+      setState(() => _finishFocus = true);
 
       widget.focus?.call(_targetFocus);
 
@@ -294,257 +437,24 @@ class AnimatedPulseFocusLightState extends AnimatedFocusLightState {
     }
   }
 
-  CustomPainter _getPainter(TargetFocus? target) {
-    if (target?.shape == ShapeLightFocus.RRect) {
-      return LightPaintRect(
-        colorShadow: target?.color ?? widget.colorShadow,
-        progress: _progressAnimated,
-        offset: _getPaddingFocus(),
-        target: _targetPosition ?? TargetPosition(Size.zero, Offset.zero),
-        radius: target?.radius ?? 0,
-        opacityShadow: widget.opacityShadow,
-      );
-    } else {
-      return LightPaint(
-        _progressAnimated,
-        _positioned,
-        _sizeCircle,
-        colorShadow: target?.color ?? widget.colorShadow,
-        opacityShadow: widget.opacityShadow,
-      );
+  void _listenerPulse(AnimationStatus status) {
+    if (status == AnimationStatus.completed) {
+      _controllerPulse.reverse();
     }
-  }
 
-  double _getPaddingFocus() {
-    return _targetFocus.paddingFocus ?? (widget.paddingFocus);
-  }
-
-  BorderRadius _betBorderRadiusTarget() {
-    double radius = _targetFocus.shape == ShapeLightFocus.Circle
-        ? (_targetPosition?.size.width ?? borderRadiusDefault)
-        : _targetFocus.radius ?? borderRadiusDefault;
-    return BorderRadius.circular(radius);
+    if (status == AnimationStatus.dismissed) {
+      if (_initReverse) {
+        setState(() => _finishFocus = false);
+        _controller.reverse();
+      } else if (_finishFocus) {
+        _controllerPulse.forward();
+      }
+    }
   }
 
   Animation _createTweenAnimation(Tween<double> tween) {
     return tween.animate(
-      CurvedAnimation(
-        parent: _controllerPulse,
-        curve: Curves.ease,
-      ),
+      CurvedAnimation(parent: _controllerPulse, curve: Curves.ease),
     );
-  }
-}
-
-class AnimatedStaticFocusLightState extends AnimatedFocusLightState {
-  late AnimationController _controller;
-  late CurvedAnimation _curvedAnimation;
-  late TargetFocus _targetFocus;
-  Offset _positioned = Offset(0.0, 0.0);
-  TargetPosition? _targetPosition;
-
-  double _sizeCircle = 100;
-  int _currentFocus = 0;
-  double _progressAnimated = 0;
-
-  bool _goNext = true;
-
-  @override
-  void initState() {
-    _targetFocus = widget.targets[_currentFocus];
-    _controller = AnimationController(
-      vsync: this,
-      duration: _targetFocus.focusAnimationDuration ??
-          widget.focusAnimationDuration ??
-          defaultFocusAnimationDuration,
-    );
-
-    _curvedAnimation = CurvedAnimation(
-      parent: _controller,
-      curve: Curves.ease,
-    );
-
-    _controller.addStatusListener(_listener);
-
-    WidgetsBinding.instance?.addPostFrameCallback((_) => _runFocus());
-    super.initState();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return InkWell(
-      onTap: _targetFocus.enableOverlayTab
-          ? () => _tapHandler(overlayTap: true)
-          : null,
-      child: AnimatedBuilder(
-        animation: _controller,
-        builder: (_, child) {
-          _progressAnimated = _curvedAnimation.value;
-          return Stack(
-            children: <Widget>[
-              Container(
-                width: double.maxFinite,
-                height: double.maxFinite,
-                child: CustomPaint(
-                  painter: _getPainter(_targetFocus),
-                ),
-              ),
-              Positioned(
-                left:
-                    (_targetPosition?.offset.dx ?? 0) - _getPaddingFocus() * 2,
-                top: (_targetPosition?.offset.dy ?? 0) - _getPaddingFocus() * 2,
-                child: InkWell(
-                  borderRadius: _betBorderRadiusTarget(),
-                  onTap: _targetFocus.enableTargetTab
-                      ? () => _tapHandler(targetTap: true)
-                      : null,
-                  child: Container(
-                    color: Colors.transparent,
-                    width: (_targetPosition?.size.width ?? 0) +
-                        _getPaddingFocus() * 4,
-                    height: (_targetPosition?.size.height ?? 0) +
-                        _getPaddingFocus() * 4,
-                  ),
-                ),
-              )
-            ],
-          );
-        },
-      ),
-    );
-  }
-
-  @override
-  void next() => _tapHandler();
-
-  @override
-  void previous() => _tapHandler(goNext: false);
-
-  void _tapHandler({
-    bool goNext = true,
-    bool targetTap = false,
-    bool overlayTap = false,
-  }) {
-    setState(() => _goNext = goNext);
-    _controller.reverse();
-
-    if (targetTap) {
-      widget.clickTarget?.call(_targetFocus);
-    }
-    if (overlayTap) {
-      widget.clickOverlay?.call(_targetFocus);
-    }
-  }
-
-  void _nextFocus() {
-    if (_currentFocus >= widget.targets.length - 1) {
-      this._finish();
-      return;
-    }
-    _currentFocus++;
-
-    _runFocus();
-  }
-
-  void _previousFocus() {
-    if (_currentFocus <= 0) {
-      this._finish();
-      return;
-    }
-    _currentFocus--;
-    _runFocus();
-  }
-
-  void _runFocus() {
-    if (_currentFocus < 0) return;
-    _targetFocus = widget.targets[_currentFocus];
-
-    _controller.duration = _targetFocus.focusAnimationDuration ??
-        widget.focusAnimationDuration ??
-        defaultFocusAnimationDuration;
-
-    var targetPosition = getTargetCurrent(_targetFocus);
-
-    if (targetPosition == null) {
-      this._finish();
-      return;
-    }
-
-    setState(() {
-      this._targetPosition = targetPosition;
-
-      _positioned = Offset(
-        targetPosition.offset.dx + (targetPosition.size.width / 2),
-        targetPosition.offset.dy + (targetPosition.size.height / 2),
-      );
-
-      if (targetPosition.size.height > targetPosition.size.width) {
-        _sizeCircle = targetPosition.size.height * 0.6 + _getPaddingFocus();
-      } else {
-        _sizeCircle = targetPosition.size.width * 0.6 + _getPaddingFocus();
-      }
-    });
-
-    _controller.forward();
-  }
-
-  void _finish() {
-    setState(() => _currentFocus = 0);
-    widget.finish!();
-  }
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
-  void _listener(AnimationStatus status) {
-    if (status == AnimationStatus.completed) {
-      widget.focus?.call(_targetFocus);
-    }
-    if (status == AnimationStatus.dismissed) {
-      if (_goNext) {
-        _nextFocus();
-      } else {
-        _previousFocus();
-      }
-    }
-
-    if (status == AnimationStatus.reverse) {
-      widget.removeFocus!();
-    }
-  }
-
-  CustomPainter _getPainter(TargetFocus? target) {
-    if (target?.shape == ShapeLightFocus.RRect) {
-      return LightPaintRect(
-        colorShadow: target?.color ?? widget.colorShadow,
-        progress: _progressAnimated,
-        offset: _getPaddingFocus(),
-        target: _targetPosition ?? TargetPosition(Size.zero, Offset.zero),
-        radius: target?.radius ?? 0,
-        opacityShadow: widget.opacityShadow,
-      );
-    } else {
-      return LightPaint(
-        _progressAnimated,
-        _positioned,
-        _sizeCircle,
-        colorShadow: target?.color ?? widget.colorShadow,
-        opacityShadow: widget.opacityShadow,
-      );
-    }
-  }
-
-  double _getPaddingFocus() {
-    return _targetFocus.paddingFocus ?? (widget.paddingFocus);
-  }
-
-  BorderRadius _betBorderRadiusTarget() {
-    double radius = _targetFocus.shape == ShapeLightFocus.Circle
-        ? _targetPosition?.size.width ?? borderRadiusDefault
-        : _targetFocus.radius ?? borderRadiusDefault;
-    return BorderRadius.circular(radius);
   }
 }

--- a/lib/src/widgets/animated_focus_light.dart
+++ b/lib/src/widgets/animated_focus_light.dart
@@ -19,6 +19,7 @@ class AnimatedFocusLight extends StatefulWidget {
   final Duration? focusAnimationDuration;
   final Duration? pulseAnimationDuration;
   final Tween<double>? pulseVariation;
+  final bool pulseEnable;
 
   const AnimatedFocusLight({
     Key? key,
@@ -34,20 +35,29 @@ class AnimatedFocusLight extends StatefulWidget {
     this.focusAnimationDuration,
     this.pulseAnimationDuration,
     this.pulseVariation,
+    this.pulseEnable = true,
   })  : assert(targets.length > 0),
         super(key: key);
 
   @override
-  AnimatedFocusLightState createState() => AnimatedFocusLightState();
+  AnimatedFocusLightState createState() => pulseEnable
+      ? AnimatedPulseFocusLightState()
+      : AnimatedStaticFocusLightState();
 }
 
-class AnimatedFocusLightState extends State<AnimatedFocusLight>
+abstract class AnimatedFocusLightState extends State<AnimatedFocusLight>
     with TickerProviderStateMixin {
-  static const BORDER_RADIUS_DEFAULT = 10.0;
-  static const DEFAULT_FOCUS_ANIMATION_DURATION = Duration(milliseconds: 600);
-  static const DEFAULT_PULSE_ANIMATION_DURATION = Duration(milliseconds: 500);
-  // ignore: non_constant_identifier_names
-  static Tween<double> DEFAULT_PULSE_VARIATION = Tween(begin: 1.0, end: 0.99);
+  final borderRadiusDefault = 10.0;
+  final defaultFocusAnimationDuration = Duration(milliseconds: 600);
+
+  void next();
+
+  void previous();
+}
+
+class AnimatedPulseFocusLightState extends AnimatedFocusLightState {
+  final defaultPulseAnimationDuration = Duration(milliseconds: 500);
+  final defaultPulseVariation = Tween(begin: 1.0, end: 0.99);
   late AnimationController _controller;
   late AnimationController _controllerPulse;
   late CurvedAnimation _curvedAnimation;
@@ -71,7 +81,7 @@ class AnimatedFocusLightState extends State<AnimatedFocusLight>
       vsync: this,
       duration: _targetFocus.focusAnimationDuration ??
           widget.focusAnimationDuration ??
-          DEFAULT_FOCUS_ANIMATION_DURATION,
+          defaultFocusAnimationDuration,
     );
 
     _curvedAnimation = CurvedAnimation(
@@ -81,13 +91,12 @@ class AnimatedFocusLightState extends State<AnimatedFocusLight>
 
     _controllerPulse = AnimationController(
       vsync: this,
-      duration:
-          widget.pulseAnimationDuration ?? DEFAULT_PULSE_ANIMATION_DURATION,
+      duration: widget.pulseAnimationDuration ?? defaultPulseAnimationDuration,
     );
 
     _tweenPulse = _createTweenAnimation(_targetFocus.pulseVariation ??
         widget.pulseVariation ??
-        DEFAULT_PULSE_VARIATION);
+        defaultPulseVariation);
 
     _controller.addStatusListener(_listener);
     _controllerPulse.addStatusListener(_listenerPulse);
@@ -149,7 +158,10 @@ class AnimatedFocusLightState extends State<AnimatedFocusLight>
     );
   }
 
+  @override
   void next() => _tapHandler();
+
+  @override
   void previous() => _tapHandler(goNext: false);
 
   void _tapHandler(
@@ -192,11 +204,11 @@ class AnimatedFocusLightState extends State<AnimatedFocusLight>
 
     _controller.duration = _targetFocus.focusAnimationDuration ??
         widget.focusAnimationDuration ??
-        DEFAULT_FOCUS_ANIMATION_DURATION;
+        defaultFocusAnimationDuration;
 
     _tweenPulse = _createTweenAnimation(_targetFocus.pulseVariation ??
         widget.pulseVariation ??
-        DEFAULT_PULSE_VARIATION);
+        defaultPulseVariation);
 
     var targetPosition = getTargetCurrent(_targetFocus);
 
@@ -309,8 +321,8 @@ class AnimatedFocusLightState extends State<AnimatedFocusLight>
 
   BorderRadius _betBorderRadiusTarget() {
     double radius = _targetFocus.shape == ShapeLightFocus.Circle
-        ? (_targetPosition?.size.width ?? BORDER_RADIUS_DEFAULT)
-        : _targetFocus.radius ?? BORDER_RADIUS_DEFAULT;
+        ? (_targetPosition?.size.width ?? borderRadiusDefault)
+        : _targetFocus.radius ?? borderRadiusDefault;
     return BorderRadius.circular(radius);
   }
 
@@ -321,5 +333,218 @@ class AnimatedFocusLightState extends State<AnimatedFocusLight>
         curve: Curves.ease,
       ),
     );
+  }
+}
+
+class AnimatedStaticFocusLightState extends AnimatedFocusLightState {
+  late AnimationController _controller;
+  late CurvedAnimation _curvedAnimation;
+  late TargetFocus _targetFocus;
+  Offset _positioned = Offset(0.0, 0.0);
+  TargetPosition? _targetPosition;
+
+  double _sizeCircle = 100;
+  int _currentFocus = 0;
+  double _progressAnimated = 0;
+
+  bool _goNext = true;
+
+  @override
+  void initState() {
+    _targetFocus = widget.targets[_currentFocus];
+    _controller = AnimationController(
+      vsync: this,
+      duration: _targetFocus.focusAnimationDuration ??
+          widget.focusAnimationDuration ??
+          defaultFocusAnimationDuration,
+    );
+
+    _curvedAnimation = CurvedAnimation(
+      parent: _controller,
+      curve: Curves.ease,
+    );
+
+    _controller.addStatusListener(_listener);
+
+    WidgetsBinding.instance?.addPostFrameCallback((_) => _runFocus());
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: _targetFocus.enableOverlayTab
+          ? () => _tapHandler(overlayTap: true)
+          : null,
+      child: AnimatedBuilder(
+        animation: _controller,
+        builder: (_, child) {
+          _progressAnimated = _curvedAnimation.value;
+          return Stack(
+            children: <Widget>[
+              Container(
+                width: double.maxFinite,
+                height: double.maxFinite,
+                child: CustomPaint(
+                  painter: _getPainter(_targetFocus),
+                ),
+              ),
+              Positioned(
+                left:
+                    (_targetPosition?.offset.dx ?? 0) - _getPaddingFocus() * 2,
+                top: (_targetPosition?.offset.dy ?? 0) - _getPaddingFocus() * 2,
+                child: InkWell(
+                  borderRadius: _betBorderRadiusTarget(),
+                  onTap: _targetFocus.enableTargetTab
+                      ? () => _tapHandler(targetTap: true)
+                      : null,
+                  child: Container(
+                    color: Colors.transparent,
+                    width: (_targetPosition?.size.width ?? 0) +
+                        _getPaddingFocus() * 4,
+                    height: (_targetPosition?.size.height ?? 0) +
+                        _getPaddingFocus() * 4,
+                  ),
+                ),
+              )
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  @override
+  void next() => _tapHandler();
+
+  @override
+  void previous() => _tapHandler(goNext: false);
+
+  void _tapHandler({
+    bool goNext = true,
+    bool targetTap = false,
+    bool overlayTap = false,
+  }) {
+    setState(() => _goNext = goNext);
+    _controller.reverse();
+
+    if (targetTap) {
+      widget.clickTarget?.call(_targetFocus);
+    }
+    if (overlayTap) {
+      widget.clickOverlay?.call(_targetFocus);
+    }
+  }
+
+  void _nextFocus() {
+    if (_currentFocus >= widget.targets.length - 1) {
+      this._finish();
+      return;
+    }
+    _currentFocus++;
+
+    _runFocus();
+  }
+
+  void _previousFocus() {
+    if (_currentFocus <= 0) {
+      this._finish();
+      return;
+    }
+    _currentFocus--;
+    _runFocus();
+  }
+
+  void _runFocus() {
+    if (_currentFocus < 0) return;
+    _targetFocus = widget.targets[_currentFocus];
+
+    _controller.duration = _targetFocus.focusAnimationDuration ??
+        widget.focusAnimationDuration ??
+        defaultFocusAnimationDuration;
+
+    var targetPosition = getTargetCurrent(_targetFocus);
+
+    if (targetPosition == null) {
+      this._finish();
+      return;
+    }
+
+    setState(() {
+      this._targetPosition = targetPosition;
+
+      _positioned = Offset(
+        targetPosition.offset.dx + (targetPosition.size.width / 2),
+        targetPosition.offset.dy + (targetPosition.size.height / 2),
+      );
+
+      if (targetPosition.size.height > targetPosition.size.width) {
+        _sizeCircle = targetPosition.size.height * 0.6 + _getPaddingFocus();
+      } else {
+        _sizeCircle = targetPosition.size.width * 0.6 + _getPaddingFocus();
+      }
+    });
+
+    _controller.forward();
+  }
+
+  void _finish() {
+    setState(() => _currentFocus = 0);
+    widget.finish!();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _listener(AnimationStatus status) {
+    if (status == AnimationStatus.completed) {
+      widget.focus?.call(_targetFocus);
+    }
+    if (status == AnimationStatus.dismissed) {
+      if (_goNext) {
+        _nextFocus();
+      } else {
+        _previousFocus();
+      }
+    }
+
+    if (status == AnimationStatus.reverse) {
+      widget.removeFocus!();
+    }
+  }
+
+  CustomPainter _getPainter(TargetFocus? target) {
+    if (target?.shape == ShapeLightFocus.RRect) {
+      return LightPaintRect(
+        colorShadow: target?.color ?? widget.colorShadow,
+        progress: _progressAnimated,
+        offset: _getPaddingFocus(),
+        target: _targetPosition ?? TargetPosition(Size.zero, Offset.zero),
+        radius: target?.radius ?? 0,
+        opacityShadow: widget.opacityShadow,
+      );
+    } else {
+      return LightPaint(
+        _progressAnimated,
+        _positioned,
+        _sizeCircle,
+        colorShadow: target?.color ?? widget.colorShadow,
+        opacityShadow: widget.opacityShadow,
+      );
+    }
+  }
+
+  double _getPaddingFocus() {
+    return _targetFocus.paddingFocus ?? (widget.paddingFocus);
+  }
+
+  BorderRadius _betBorderRadiusTarget() {
+    double radius = _targetFocus.shape == ShapeLightFocus.Circle
+        ? _targetPosition?.size.width ?? borderRadiusDefault
+        : _targetFocus.radius ?? borderRadiusDefault;
+    return BorderRadius.circular(radius);
   }
 }

--- a/lib/src/widgets/tutorial_coach_mark_widget.dart
+++ b/lib/src/widgets/tutorial_coach_mark_widget.dart
@@ -22,6 +22,7 @@ class TutorialCoachMarkWidget extends StatefulWidget {
     this.focusAnimationDuration,
     this.pulseAnimationDuration,
     this.pulseVariation,
+    this.pulseEnable = true,
     this.skipWidget,
   })  : assert(targets.length > 0),
         super(key: key);
@@ -41,6 +42,7 @@ class TutorialCoachMarkWidget extends StatefulWidget {
   final Duration? focusAnimationDuration;
   final Duration? pulseAnimationDuration;
   final Tween<double>? pulseVariation;
+  final bool pulseEnable;
   final Widget? skipWidget;
 
   @override
@@ -69,6 +71,7 @@ class TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget>
             focusAnimationDuration: widget.focusAnimationDuration,
             pulseAnimationDuration: widget.pulseAnimationDuration,
             pulseVariation: widget.pulseVariation,
+            pulseEnable: widget.pulseEnable,
             clickTarget: (target) {
               widget.clickTarget?.call(target);
             },

--- a/lib/tutorial_coach_mark.dart
+++ b/lib/tutorial_coach_mark.dart
@@ -26,6 +26,7 @@ class TutorialCoachMark {
   final GlobalKey<TutorialCoachMarkWidgetState> _widgetKey = GlobalKey();
   final Duration focusAnimationDuration;
   final Duration pulseAnimationDuration;
+  final bool pulseEnable;
   final Widget? skipWidget;
 
   OverlayEntry? _overlayEntry;
@@ -45,6 +46,7 @@ class TutorialCoachMark {
       this.opacityShadow = 0.8,
       this.focusAnimationDuration = const Duration(milliseconds: 600),
       this.pulseAnimationDuration = const Duration(milliseconds: 500),
+      this.pulseEnable = true,
       this.skipWidget})
       : assert(opacityShadow >= 0 && opacityShadow <= 1);
 
@@ -67,6 +69,7 @@ class TutorialCoachMark {
           opacityShadow: opacityShadow,
           focusAnimationDuration: focusAnimationDuration,
           pulseAnimationDuration: pulseAnimationDuration,
+          pulseEnable: pulseEnable,
           finish: finish,
         );
       },


### PR DESCRIPTION
This PR adds the option to enable/disable the pulse animation by adding a new variable to the `TutorialCoachMark` class.
 
I thought the clearest way to add this feature would be to separate the `AnimatedFocusLightState` into two classes, one for a static focus and another one for a dynamic focus with a pulse animation.