### PR TITLE
Add a refresh function to TutorialCoachMark and add unFocusAnimationDuration to TargetFocus

### DIFF
--- a/lib/src/target/target_focus.dart
+++ b/lib/src/target/target_focus.dart
@@ -18,6 +18,7 @@ class TargetFocus {
     this.alignSkip,
     this.paddingFocus,
     this.focusAnimationDuration,
+    this.unFocusAnimationDuration,
     this.pulseVariation,
   }) : assert(keyTarget != null || targetPosition != null);
 
@@ -34,6 +35,7 @@ class TargetFocus {
   final AlignmentGeometry? alignSkip;
   final double? paddingFocus;
   final Duration? focusAnimationDuration;
+  final Duration? unFocusAnimationDuration;
   final Tween<double>? pulseVariation;
 
   @override

--- a/lib/src/widgets/animated_focus_light.dart
+++ b/lib/src/widgets/animated_focus_light.dart
@@ -285,7 +285,8 @@ class AnimatedStaticFocusLightState extends AnimatedFocusLightState {
     });
 
     _controller.forward();
-    _controller.duration = widget.unFocusAnimationDuration ??
+    _controller.duration = _targetFocus.unFocusAnimationDuration ??
+        widget.unFocusAnimationDuration ??
         _targetFocus.focusAnimationDuration ??
         widget.focusAnimationDuration ??
         defaultFocusAnimationDuration;
@@ -424,7 +425,8 @@ class AnimatedPulseFocusLightState extends AnimatedFocusLightState {
     });
 
     _controller.forward();
-    _controller.duration = widget.unFocusAnimationDuration ??
+    _controller.duration = _targetFocus.unFocusAnimationDuration ??
+        widget.unFocusAnimationDuration ??
         _targetFocus.focusAnimationDuration ??
         widget.focusAnimationDuration ??
         defaultFocusAnimationDuration;

--- a/lib/src/widgets/animated_focus_light.dart
+++ b/lib/src/widgets/animated_focus_light.dart
@@ -93,6 +93,30 @@ abstract class AnimatedFocusLightState extends State<AnimatedFocusLight>
 
   void previous() => _tapHandler(goNext: false);
 
+  void refresh() {
+    var targetPosition = getTargetCurrent(_targetFocus);
+
+    if (targetPosition == null) {
+      _finish();
+      return;
+    }
+
+    setState(() {
+      _targetPosition = getTargetCurrent(_targetFocus);
+
+      _positioned = Offset(
+        targetPosition.offset.dx + (targetPosition.size.width / 2),
+        targetPosition.offset.dy + (targetPosition.size.height / 2),
+      );
+
+      if (targetPosition.size.height > targetPosition.size.width) {
+        _sizeCircle = targetPosition.size.height * 0.6 + _getPaddingFocus();
+      } else {
+        _sizeCircle = targetPosition.size.width * 0.6 + _getPaddingFocus();
+      }
+    });
+  }
+
   Future _tapHandler({
     bool goNext = true,
     bool targetTap = false,

--- a/lib/src/widgets/tutorial_coach_mark_widget.dart
+++ b/lib/src/widgets/tutorial_coach_mark_widget.dart
@@ -246,4 +246,6 @@ class TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget>
   void next() => _focusLightKey.currentState?.next();
 
   void previous() => _focusLightKey.currentState?.previous();
+
+  void refresh() => _focusLightKey.currentState?.refresh();
 }

--- a/lib/tutorial_coach_mark.dart
+++ b/lib/tutorial_coach_mark.dart
@@ -106,6 +106,8 @@ class TutorialCoachMark {
 
   void previous() => _widgetKey.currentState?.previous();
 
+  void refresh() => _widgetKey.currentState?.refresh();
+
   void _removeOverlay() {
     _overlayEntry?.remove();
     _overlayEntry = null;


### PR DESCRIPTION
## Add a refresh function to TutorialCoachMark

This can be called to update the position and size of the current target.
It can be called after the orientation changed
#66 

## Add unFocusAnimationDuration to TargetFocus

Customize unFocusAnimationDuration for each target.