### PR TITLE
Fixed target global position when using rootOverlay and inner navigator

### DIFF
--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -4,7 +4,10 @@ import 'package:tutorial_coach_mark/src/target/target_position.dart';
 
 enum ShapeLightFocus { Circle, RRect }
 
-TargetPosition? getTargetCurrent(TargetFocus target) {
+TargetPosition? getTargetCurrent(
+  TargetFocus target, {
+  bool rootOverlay = false,
+}) {
   if (target.keyTarget != null) {
     var key = target.keyTarget!;
 
@@ -12,12 +15,23 @@ TargetPosition? getTargetCurrent(TargetFocus target) {
       final RenderBox renderBoxRed =
           key.currentContext!.findRenderObject() as RenderBox;
       final size = renderBoxRed.size;
-      final state =
-          key.currentContext!.findAncestorStateOfType<NavigatorState>();
+
+      BuildContext? context;
+      if (rootOverlay) {
+        context = key.currentContext!
+            .findRootAncestorStateOfType<OverlayState>()
+            ?.context;
+      } else {
+        context = key.currentContext!
+            .findAncestorStateOfType<NavigatorState>()
+            ?.context;
+      }
       Offset offset;
-      if (state != null) {
-        offset = renderBoxRed.localToGlobal(Offset.zero,
-            ancestor: state.context.findRenderObject());
+      if (context != null) {
+        offset = renderBoxRed.localToGlobal(
+          Offset.zero,
+          ancestor: context.findRenderObject(),
+        );
       } else {
         offset = renderBoxRed.localToGlobal(Offset.zero);
       }

--- a/lib/src/widgets/animated_focus_light.dart
+++ b/lib/src/widgets/animated_focus_light.dart
@@ -24,6 +24,7 @@ class AnimatedFocusLight extends StatefulWidget {
   final Duration? pulseAnimationDuration;
   final Tween<double>? pulseVariation;
   final bool pulseEnable;
+  final bool rootOverlay;
 
   const AnimatedFocusLight({
     Key? key,
@@ -42,6 +43,7 @@ class AnimatedFocusLight extends StatefulWidget {
     this.pulseAnimationDuration,
     this.pulseVariation,
     this.pulseEnable = true,
+    this.rootOverlay = false,
   })  : assert(targets.length > 0),
         super(key: key);
 
@@ -255,7 +257,10 @@ class AnimatedStaticFocusLightState extends AnimatedFocusLightState {
         widget.focusAnimationDuration ??
         defaultFocusAnimationDuration;
 
-    var targetPosition = getTargetCurrent(_targetFocus);
+    var targetPosition = getTargetCurrent(
+      _targetFocus,
+      rootOverlay: widget.rootOverlay,
+    );
 
     if (targetPosition == null) {
       _finish();
@@ -398,7 +403,10 @@ class AnimatedPulseFocusLightState extends AnimatedFocusLightState {
         widget.pulseVariation ??
         defaultPulseVariation);
 
-    var targetPosition = getTargetCurrent(_targetFocus);
+    var targetPosition = getTargetCurrent(
+      _targetFocus,
+      rootOverlay: widget.rootOverlay,
+    );
 
     if (targetPosition == null) {
       _finish();

--- a/lib/src/widgets/tutorial_coach_mark_widget.dart
+++ b/lib/src/widgets/tutorial_coach_mark_widget.dart
@@ -28,6 +28,7 @@ class TutorialCoachMarkWidget extends StatefulWidget {
     this.pulseVariation,
     this.pulseEnable = true,
     this.skipWidget,
+    this.rootOverlay = false,
   })  : assert(targets.length > 0),
         super(key: key);
 
@@ -50,6 +51,7 @@ class TutorialCoachMarkWidget extends StatefulWidget {
   final Tween<double>? pulseVariation;
   final bool pulseEnable;
   final Widget? skipWidget;
+  final bool rootOverlay;
 
   @override
   TutorialCoachMarkWidgetState createState() => TutorialCoachMarkWidgetState();
@@ -78,6 +80,7 @@ class TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget> implem
             pulseAnimationDuration: widget.pulseAnimationDuration,
             pulseVariation: widget.pulseVariation,
             pulseEnable: widget.pulseEnable,
+            rootOverlay: widget.rootOverlay,
             clickTarget: (target) {
               return widget.clickTarget?.call(target);
             },
@@ -117,7 +120,10 @@ class TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget> implem
 
     List<Widget> children = <Widget>[];
 
-    final target = getTargetCurrent(currentTarget!);
+    final target = getTargetCurrent(
+      currentTarget!,
+      rootOverlay: widget.rootOverlay,
+    );
     if (target == null) {
       return SizedBox.shrink();
     }

--- a/lib/tutorial_coach_mark.dart
+++ b/lib/tutorial_coach_mark.dart
@@ -56,7 +56,7 @@ class TutorialCoachMark {
     this.skipWidget,
   }) : assert(opacityShadow >= 0 && opacityShadow <= 1);
 
-  OverlayEntry _buildOverlay() {
+  OverlayEntry _buildOverlay({bool rootOverlay = false}) {
     return OverlayEntry(
       builder: (context) {
         return TutorialCoachMarkWidget(
@@ -79,6 +79,7 @@ class TutorialCoachMark {
           pulseAnimationDuration: pulseAnimationDuration,
           pulseEnable: pulseEnable,
           finish: finish,
+          rootOverlay: rootOverlay,
         );
       },
     );
@@ -87,7 +88,7 @@ class TutorialCoachMark {
   void show({required BuildContext context, bool rootOverlay = false}) {
     Future.delayed(Duration.zero, () {
       if (_overlayEntry == null) {
-        _overlayEntry = _buildOverlay();
+        _overlayEntry = _buildOverlay(rootOverlay: rootOverlay);
         Overlay.of(context, rootOverlay: rootOverlay)?.insert(_overlayEntry!);
       }
     });


### PR DESCRIPTION
# Description

When using an inner navigator or on more complex use cases, there is offset between the tutorial target and the real widget position if using rootOverlay. This PR import the rootOverlay value to use it on the `getTargetCurrent` function, to use root Overlay context for RendeObject position.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I open this PR to the `develop` branch.
- [ ] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [X] I ran `flutter format --set-exit-if-changed --dry-run .` and has success.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [X] No, this is *not* a breaking change.