### PR TITLE
Catch `NotFoundTargetException` to prevent the app being left in unusable state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # next
 - Adds `showSkipInLastTarget`.
+- Catch `NotFoundTargetException` to prevent the app being left in unusable state
 
 # 1.2.6
 - Improvements in `AnimatedFocusLight`;

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -39,7 +39,7 @@ TargetPosition? getTargetCurrent(
 
       return TargetPosition(size, offset);
     } catch (e) {
-      throw NotFoundTargeException();
+      throw NotFoundTargetException();
     }
   } else {
     return target.targetPosition;
@@ -61,7 +61,7 @@ extension StateExt on State {
   }
 }
 
-class NotFoundTargeException extends FormatException {
-  NotFoundTargeException()
+class NotFoundTargetException extends FormatException {
+  NotFoundTargetException()
       : super('It was not possible to obtain target position.');
 }

--- a/lib/src/widgets/animated_focus_light.dart
+++ b/lib/src/widgets/animated_focus_light.dart
@@ -124,10 +124,16 @@ abstract class AnimatedFocusLightState extends State<AnimatedFocusLight>
         widget.focusAnimationDuration ??
         defaultFocusAnimationDuration;
 
-    var targetPosition = getTargetCurrent(
-      _targetFocus,
-      rootOverlay: widget.rootOverlay,
-    );
+    TargetPosition? targetPosition;
+    try {
+      targetPosition = getTargetCurrent(
+        _targetFocus,
+        rootOverlay: widget.rootOverlay,
+      );
+    } on NotFoundTargetException catch (e, s) {
+      debugPrint(e.toString());
+      debugPrintStack(stackTrace: s);
+    }
 
     if (targetPosition == null) {
       _finish();
@@ -135,7 +141,7 @@ abstract class AnimatedFocusLightState extends State<AnimatedFocusLight>
     }
 
     safeSetState(() {
-      _targetPosition = targetPosition;
+      _targetPosition = targetPosition!;
 
       _positioned = Offset(
         targetPosition.offset.dx + (targetPosition.size.width / 2),
@@ -220,6 +226,7 @@ abstract class AnimatedFocusLightState extends State<AnimatedFocusLight>
 
 class AnimatedStaticFocusLightState extends AnimatedFocusLightState {
   double get left => (_targetPosition?.offset.dx ?? 0) - _getPaddingFocus() * 2;
+
   double get top => (_targetPosition?.offset.dy ?? 0) - _getPaddingFocus() * 2;
 
   double get width {

--- a/lib/src/widgets/tutorial_coach_mark_widget.dart
+++ b/lib/src/widgets/tutorial_coach_mark_widget.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:tutorial_coach_mark/src/target/target_content.dart';
 import 'package:tutorial_coach_mark/src/target/target_focus.dart';
+import 'package:tutorial_coach_mark/src/target/target_position.dart';
 import 'package:tutorial_coach_mark/src/util.dart';
 import 'package:tutorial_coach_mark/src/widgets/animated_focus_light.dart';
 
@@ -125,10 +126,17 @@ class TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget>
 
     List<Widget> children = <Widget>[];
 
-    final target = getTargetCurrent(
-      currentTarget!,
-      rootOverlay: widget.rootOverlay,
-    );
+    TargetPosition? target;
+    try {
+      target = getTargetCurrent(
+        currentTarget!,
+        rootOverlay: widget.rootOverlay,
+      );
+    } on NotFoundTargetException catch (e, s) {
+      debugPrint(e.toString());
+      debugPrintStack(stackTrace: s);
+    }
+
     if (target == null) {
       return const SizedBox.shrink();
     }
@@ -183,14 +191,14 @@ class TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget>
           {
             weight = positioned.dx - haloWidth;
             left = 0;
-            top = positioned.dy - target.size.height / 2 - haloHeight;
+            top = positioned.dy - target!.size.height / 2 - haloHeight;
             bottom = null;
           }
           break;
         case ContentAlign.right:
           {
             left = positioned.dx + haloWidth;
-            top = positioned.dy - target.size.height / 2 - haloHeight;
+            top = positioned.dy - target!.size.height / 2 - haloHeight;
             bottom = null;
             weight = MediaQuery.of(context).size.width - left!;
           }


### PR DESCRIPTION
# Description

Following up my comment [here](https://github.com/RafaelBarbosatec/tutorial_coach_mark/issues/128#issuecomment-1445196347), I don't think `NotFoundTargetException` works as expected: it not possible to catch the exception and if the target position cannot be found the app is left in an unusable state, with a transparent overlay that prevents everything from being tapped and no clue for the user on how to fix it.

This is a patch to catch `NotFoundTargetException` in the library itself and just ignore the missing target. 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I open this PR to the `develop` branch.
- [X] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [X] I ran `flutter format --set-exit-if-changed --dry-run .` and has success.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [X] No, this is *not* a breaking change.