### PR TITLE
fix: remove breaking changes

### DIFF
--- a/lib/tutorial_coach_mark.dart
+++ b/lib/tutorial_coach_mark.dart
@@ -55,7 +55,7 @@ class TutorialCoachMark {
     this.pulseAnimationDuration = const Duration(milliseconds: 500),
     this.pulseEnable = true,
     this.skipWidget,
-    this.showSkipInLastTarget = false,
+    this.showSkipInLastTarget = true,
   }) : assert(opacityShadow >= 0 && opacityShadow <= 1);
 
   OverlayEntry _buildOverlay({bool rootOverlay = false}) {


### PR DESCRIPTION
Hi @RafaelBarbosatec to help i changed the default parameter to true as it was a non-breaking change, the behaviour should never change without a breaking change(this is  why the default parameter must be true).

Abraços
