### PR TITLE
Added Swipe up target using vertical drag

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -233,6 +233,9 @@ class MyHomePageState extends State<MyHomePage> {
       onFinish: () {
         print("finish");
       },
+      onVerticalDragTargetEnd: (target) {
+        print('onDragTargetSwipeUp: $target');
+      },
       onClickTarget: (target) {
         print('onClickTarget: $target');
       },

--- a/lib/src/widgets/animated_focus_light.dart
+++ b/lib/src/widgets/animated_focus_light.dart
@@ -11,6 +11,7 @@ class AnimatedFocusLight extends StatefulWidget {
   final List<TargetFocus> targets;
   final Function(TargetFocus)? focus;
   final FutureOr Function(TargetFocus)? clickTarget;
+  final FutureOr Function(TargetFocus)? onVerticalDragTargetEnd;
   final FutureOr Function(TargetFocus, TapDownDetails)?
       clickTargetWithTapPosition;
   final FutureOr Function(TargetFocus)? clickOverlay;
@@ -33,6 +34,7 @@ class AnimatedFocusLight extends StatefulWidget {
     this.finish,
     this.removeFocus,
     this.clickTarget,
+    this.onVerticalDragTargetEnd,
     this.clickTargetWithTapPosition,
     this.clickOverlay,
     this.paddingFocus = 10,
@@ -102,10 +104,14 @@ abstract class AnimatedFocusLightState extends State<AnimatedFocusLight>
   Future _tapHandler({
     bool goNext = true,
     bool targetTap = false,
+    bool targetVerticalDrag = false,
     bool overlayTap = false,
   }) async {
     if (targetTap) {
       await widget.clickTarget?.call(_targetFocus);
+    }
+    if (targetVerticalDrag) {
+      await widget.onVerticalDragTargetEnd?.call(_targetFocus);
     }
     if (overlayTap) {
       await widget.clickOverlay?.call(_targetFocus);
@@ -267,10 +273,14 @@ class AnimatedStaticFocusLightState extends AnimatedFocusLightState {
 
                       /// Essential for collecting [TapDownDetails]. Do not make [null]
                       : () {},
-                  child: Container(
-                    color: Colors.transparent,
-                    width: width,
-                    height: height,
+                  child: GestureDetector(
+                    onVerticalDragEnd: (_) =>
+                        _tapHandler(targetVerticalDrag: true),
+                    child: Container(
+                      color: Colors.transparent,
+                      width: width,
+                      height: height,
+                    ),
                   ),
                 ),
               )
@@ -285,11 +295,13 @@ class AnimatedStaticFocusLightState extends AnimatedFocusLightState {
   Future _tapHandler({
     bool goNext = true,
     bool targetTap = false,
+    bool targetVerticalDrag = false,
     bool overlayTap = false,
   }) async {
     await super._tapHandler(
       goNext: goNext,
       targetTap: targetTap,
+      targetVerticalDrag: targetVerticalDrag,
       overlayTap: overlayTap,
     );
     safeSetState(() => _goNext = goNext);
@@ -383,10 +395,14 @@ class AnimatedPulseFocusLightState extends AnimatedFocusLightState {
                           /// Essential for collecting [TapDownDetails]. Do not make [null]
                           : () {},
                       onTapDown: _tapHandlerForPosition,
-                      child: Container(
-                        color: Colors.transparent,
-                        width: width,
-                        height: height,
+                      child: GestureDetector(
+                        onVerticalDragEnd: (_) =>
+                            _tapHandler(targetVerticalDrag: true),
+                        child: Container(
+                          color: Colors.transparent,
+                          width: width,
+                          height: height,
+                        ),
                       ),
                     ),
                   )
@@ -412,11 +428,13 @@ class AnimatedPulseFocusLightState extends AnimatedFocusLightState {
   Future _tapHandler({
     bool goNext = true,
     bool targetTap = false,
+    bool targetVerticalDrag = false,
     bool overlayTap = false,
   }) async {
     await super._tapHandler(
       goNext: goNext,
       targetTap: targetTap,
+      targetVerticalDrag: targetVerticalDrag,
       overlayTap: overlayTap,
     );
     if (mounted) {

--- a/lib/src/widgets/tutorial_coach_mark_widget.dart
+++ b/lib/src/widgets/tutorial_coach_mark_widget.dart
@@ -14,6 +14,7 @@ class TutorialCoachMarkWidget extends StatefulWidget {
     this.finish,
     this.paddingFocus = 10,
     this.clickTarget,
+    this.onVerticalDragTargetEnd,
     this.onClickTargetWithTapPosition,
     this.clickOverlay,
     this.alignSkip = Alignment.bottomRight,
@@ -36,6 +37,7 @@ class TutorialCoachMarkWidget extends StatefulWidget {
 
   final List<TargetFocus> targets;
   final FutureOr Function(TargetFocus)? clickTarget;
+  final FutureOr Function(TargetFocus)? onVerticalDragTargetEnd;
   final FutureOr Function(TargetFocus, TapDownDetails)?
       onClickTargetWithTapPosition;
   final FutureOr Function(TargetFocus)? clickOverlay;
@@ -88,6 +90,9 @@ class TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget>
             rootOverlay: widget.rootOverlay,
             clickTarget: (target) {
               return widget.clickTarget?.call(target);
+            },
+            onVerticalDragTargetEnd: (target) {
+              return widget.onVerticalDragTargetEnd?.call(target);
             },
             clickTargetWithTapPosition: (target, tapDetails) {
               return widget.onClickTargetWithTapPosition

--- a/lib/tutorial_coach_mark.dart
+++ b/lib/tutorial_coach_mark.dart
@@ -14,6 +14,7 @@ export 'package:tutorial_coach_mark/src/util.dart';
 class TutorialCoachMark {
   final List<TargetFocus> targets;
   final FutureOr<void> Function(TargetFocus)? onClickTarget;
+  final FutureOr<void> Function(TargetFocus)? onVerticalDragTargetEnd;
   final FutureOr<void> Function(TargetFocus, TapDownDetails)?
       onClickTargetWithTapPosition;
   final FutureOr<void> Function(TargetFocus)? onClickOverlay;
@@ -40,6 +41,7 @@ class TutorialCoachMark {
     required this.targets,
     this.colorShadow = Colors.black,
     this.onClickTarget,
+    this.onVerticalDragTargetEnd,
     this.onClickTargetWithTapPosition,
     this.onClickOverlay,
     this.onFinish,
@@ -65,6 +67,7 @@ class TutorialCoachMark {
           key: _widgetKey,
           targets: targets,
           clickTarget: onClickTarget,
+          onVerticalDragTargetEnd: onVerticalDragTargetEnd,
           onClickTargetWithTapPosition: onClickTargetWithTapPosition,
           clickOverlay: onClickOverlay,
           paddingFocus: paddingFocus,


### PR DESCRIPTION

This PR adds onVerticalDragTargetEnd method to drag or swipeup on target.

Call function when user drag or swipe up on target and load next page using onVerticalDragTargetEnd function.
i.e Swipe up to move through the videos feed