### PR TITLE
Add option to show tutorial without context - vol2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.2.9
+- Adds option to show the tutorial without context.
+
 # 1.2.8
 - Adds Method 'insert' cannot be called on 'OverlayState?' because it is potentially null. Called using ?. instead.
 

--- a/lib/tutorial_coach_mark.dart
+++ b/lib/tutorial_coach_mark.dart
@@ -98,6 +98,16 @@ class TutorialCoachMark {
     });
   }
 
+  void showWithoutContext({required GlobalKey<NavigatorState> navigatorKey, bool rootOverlay = false}) {
+    // `navigatorKey` needs to be the one that you passed to MaterialApp.navigatorKey
+    Future.delayed(Duration.zero, () {
+      if (_overlayEntry == null) {
+        _overlayEntry = _buildOverlay(rootOverlay: rootOverlay);
+        navigatorKey.currentState?.overlay?.insert(_overlayEntry!);
+      }
+    });
+  }
+
   void finish() {
     onFinish?.call();
     _removeOverlay();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tutorial_coach_mark
 description: Guide that helps you to present your app and its features in a beautiful, simple and customizable way. Tutorial | Guide | Coach.
-version: 1.2.8
+version: 1.2.9
 homepage: https://github.com/RafaelBarbosatec/tutorial_coach_mark
 
 environment:


### PR DESCRIPTION
# Description
See #121 

There are scenarios when you need to launch the tutorial from a service and you don't have access to `BuildContext`. Also, some state managements like `Stacked` or `GetX` are moving away from the burden of passing the context to business layers. So IMHO it's quite important to have a way how to use this package without the context.

Any discussion is more than welcome.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I open this PR to the `develop` branch.
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I ran `flutter format --set-exit-if-changed --dry-run .` and has success.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.