### PR TITLE
change current-focus of the tutorial 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # next
 - now `onSkip` return a bool. if onSkip return false, the overlay will not be dismissed and call `next`. [#89](https://github.com/RafaelBarbosatec/tutorial_coach_mark/issues/89)
+- Added the functionality "currentFocus" to change the foucs of the tutorial. On setting the "currentFocus" to an int we will be able to switch to the widget of focus we want
 
 # 1.2.9
 - set `ignoringSemantics` false in `skip` button. Reolve [#156](https://github.com/RafaelBarbosatec/tutorial_coach_mark/issues/156)


### PR DESCRIPTION
"currentFocus" changing functionality

# Description

Added functionality to set the "currentFocus" of the target content widget of the tutorial. On setting the currentFocus from the tutorial coach mark constructor you can set the current focus to any widget you want in the tutorial. 
I was working on a dynamic tutorial where we were taking user input in the tutorial itself and then we wanted to implement a feature where we were able to save the state of the widget we were in, we achieved this using shared preferences and returing a shorter list based on the shared preference logic but as now the list<TargetFocus> was shorter we weren't able to go back to the previous widget of TargetFocus, so added the currentFocus in the constructor  of tutorial coach mark to be able to change the current focus to any widget you want dynamically and without returing a shorter list. 
Tried various methods but expect this none of them worked like the way we wanted

This is my first time contributing to github, please be light on me.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I open this PR to the `develop` branch.
- [x] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I ran `flutter format --set-exit-if-changed --dry-run .` and has success.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x ] No, this is *not* a breaking change.