### PR TITLE
Add identifier to NotFoundTargetException for debugging

### DIFF
--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -39,7 +39,7 @@ TargetPosition? getTargetCurrent(
 
       return TargetPosition(size, offset);
     } catch (e) {
-      throw NotFoundTargetException();
+      throw NotFoundTargetException(target.identify);
     }
   } else {
     return target.targetPosition;
@@ -62,8 +62,8 @@ extension StateExt on State {
 }
 
 class NotFoundTargetException extends FormatException {
-  NotFoundTargetException()
-      : super('It was not possible to obtain target position.');
+  NotFoundTargetException(identify)
+      : super('It was not possible to obtain target position ($identify).');
 }
 
 void postFrame(VoidCallback callback) {


### PR DESCRIPTION
# Description

While developing (or in production, in case of errors) a `NotFoundTargetException` can be raised. When this happens it can be hard to spot which target is not found, so printing the target identifier along with the exception itself helps a lot.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I open this PR to the `develop` branch.
- [ ] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I ran `flutter format --set-exit-if-changed --dry-run .` and has success.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.