### PR TITLE
Fix: target content positioning and sizing issue when used within nested navigators

### DIFF
--- a/lib/src/widgets/tutorial_coach_mark_widget.dart
+++ b/lib/src/widgets/tutorial_coach_mark_widget.dart
@@ -166,17 +166,19 @@ class TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget>
     haloWidth = haloWidth * 0.6 + widget.paddingFocus;
     haloHeight = haloHeight * 0.6 + widget.paddingFocus;
 
-    double weight = 0.0;
+    double width = 0.0;
     double? top;
     double? bottom;
     double? left;
     double? right;
 
+    final ancestorBox = context.findRenderObject() as RenderBox;
+
     children = currentTarget!.contents!.map<Widget>((i) {
       switch (i.align) {
         case ContentAlign.bottom:
           {
-            weight = MediaQuery.of(context).size.width;
+            width = ancestorBox.size.width;
             left = 0;
             top = positioned.dy + haloHeight;
             bottom = null;
@@ -184,16 +186,15 @@ class TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget>
           break;
         case ContentAlign.top:
           {
-            weight = MediaQuery.of(context).size.width;
+            width = ancestorBox.size.width;
             left = 0;
             top = null;
-            bottom = haloHeight +
-                (MediaQuery.of(context).size.height - positioned.dy);
+            bottom = haloHeight + (ancestorBox.size.height - positioned.dy);
           }
           break;
         case ContentAlign.left:
           {
-            weight = positioned.dx - haloWidth;
+            width = positioned.dx - haloWidth;
             left = 0;
             top = positioned.dy - target!.size.height / 2 - haloHeight;
             bottom = null;
@@ -204,7 +205,7 @@ class TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget>
             left = positioned.dx + haloWidth;
             top = positioned.dy - target!.size.height / 2 - haloHeight;
             bottom = null;
-            weight = MediaQuery.of(context).size.width - left!;
+            width = ancestorBox.size.width - left!;
           }
           break;
         case ContentAlign.custom:
@@ -213,7 +214,7 @@ class TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget>
             right = i.customPosition!.right;
             top = i.customPosition!.top;
             bottom = i.customPosition!.bottom;
-            weight = MediaQuery.of(context).size.width;
+            width = ancestorBox.size.width;
           }
           break;
       }
@@ -224,7 +225,7 @@ class TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget>
         left: left,
         right: right,
         child: SizedBox(
-          width: weight,
+          width: width,
           child: Padding(
             padding: i.padding,
             child: i.builder?.call(context, this) ??


### PR DESCRIPTION
# Description

When using nested navigators that are smaller than the screen size, for example when using NavigationRail, target contents could be improperly offset depending on the alignment. This PR fixes the issue by replacing MediaQuery references to the context render box to determine the overlay size.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I open this PR to the `develop` branch.
- [ ] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [x] I ran `flutter format --set-exit-if-changed --dry-run .` and has success.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.