### PR TITLE
fix logic to allow focus and unfocus animation duration to work properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.2.10
+- Change moment where call `_controller.forward()` occurs. That prevents the `unFocusAnimationDuration` is always called;
+
 # 1.2.9
 - set `ignoringSemantics` false in `skip` button. Reolve [#156](https://github.com/RafaelBarbosatec/tutorial_coach_mark/issues/156)
 - adds `ImageFilter`. Now is possible apply blur in the shadow. [#151](https://github.com/RafaelBarbosatec/tutorial_coach_mark/issues/151)

--- a/lib/src/widgets/animated_focus_light.dart
+++ b/lib/src/widgets/animated_focus_light.dart
@@ -160,12 +160,12 @@ abstract class AnimatedFocusLightState extends State<AnimatedFocusLight>
       }
     });
 
+    _controller.forward();
     _controller.duration = _targetFocus.unFocusAnimationDuration ??
         widget.unFocusAnimationDuration ??
         _targetFocus.focusAnimationDuration ??
         widget.focusAnimationDuration ??
         defaultFocusAnimationDuration;
-    _controller.forward();
   }
 
   void _nextFocus() {


### PR DESCRIPTION
# Fix Logic that allow focus and unfocus animation duration to work as chosen

* The call to update the controller's duration before reversing it is being done after the update.
So the duration of the controller is always using the unFocusAnimationDuration

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I open this PR to the `develop` branch.
- [X] I have added a description of the change under `[next]` in `CHANGELOG.md`.
- [X] I ran `flutter format --set-exit-if-changed --dry-run .` and has success.

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [X] No, this is *not* a breaking change.