### PR TITLE
Fix: Custom skipWidget not triggering tutorial skip action

### DIFF
--- a/lib/src/widgets/tutorial_coach_mark_widget.dart
+++ b/lib/src/widgets/tutorial_coach_mark_widget.dart
@@ -281,20 +281,21 @@ class TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget>
         child: AnimatedOpacity(
           opacity: showContent ? 1 : 0,
           duration: Durations.medium2,
-          child: widget.skipWidget ??
-              InkWell(
-                onTap: skip,
-                child: IgnorePointer(
-                  child: widget.skipWidget ??
-                      Padding(
-                        padding: const EdgeInsets.all(20.0),
-                        child: Text(
-                          widget.textSkip,
-                          style: widget.textStyleSkip,
-                        ),
-                      ),
-                ),
+          child: widget.skipWidget != null
+              ? InkWell(
+            onTap: skip,
+            child: widget.skipWidget,
+          )
+              : InkWell(
+            onTap: skip,
+            child: Padding(
+              padding: const EdgeInsets.all(20.0),
+              child: Text(
+                widget.textSkip,
+                style: widget.textStyleSkip,
               ),
+            ),
+          ),
         ),
       ),
     );


### PR DESCRIPTION
skipWidget was outside the inkwell before. have added an inkwell with ontap: skip so the skip function works normally