### PR TITLE
Inline documentation, enable rebuilding on screen resize

### DIFF
--- a/lib/src/target/target_content.dart
+++ b/lib/src/target/target_content.dart
@@ -3,6 +3,18 @@ import 'package:flutter/widgets.dart';
 
 import '../../tutorial_coach_mark.dart';
 
+/// Defines custom positioning for tutorial content when using [ContentAlign.custom].
+///
+/// Use this class to specify exact positioning of content relative to the screen edges.
+/// At least one positioning parameter must be provided.
+///
+/// Example:
+/// ```dart
+/// CustomTargetContentPosition(
+///   top: 100.0,
+///   left: 50.0,
+/// )
+/// ```
 class CustomTargetContentPosition {
   CustomTargetContentPosition({
     this.top,
@@ -11,7 +23,17 @@ class CustomTargetContentPosition {
     this.bottom,
   });
 
-  final double? top, left, right, bottom;
+  /// Distance from the top edge of the screen.
+  final double? top;
+  
+  /// Distance from the left edge of the screen.
+  final double? left;
+  
+  /// Distance from the right edge of the screen.
+  final double? right;
+  
+  /// Distance from the bottom edge of the screen.
+  final double? bottom;
 
   @override
   String toString() {
@@ -19,13 +41,61 @@ class CustomTargetContentPosition {
   }
 }
 
-enum ContentAlign { top, bottom, left, right, custom }
+/// Defines where the content should be positioned relative to the target widget.
+enum ContentAlign { 
+  /// Position content above the target widget.
+  top, 
+  /// Position content below the target widget.
+  bottom, 
+  /// Position content to the left of the target widget.
+  left, 
+  /// Position content to the right of the target widget.
+  right, 
+  /// Use custom positioning with [CustomTargetContentPosition].
+  custom 
+}
 
+/// Builder function for creating dynamic tutorial content.
+///
+/// Provides access to [BuildContext] and [TutorialCoachMarkController]
+/// for creating interactive or context-aware content.
 typedef TargetContentBuilder = Widget Function(
   BuildContext context,
   TutorialCoachMarkController controller,
 );
 
+/// Represents content to be displayed around a focused target widget.
+///
+/// Each [TargetContent] defines what should be shown and where it should be
+/// positioned relative to the focused widget. You can use either a static
+/// [child] widget or a dynamic [builder] function.
+///
+/// Example with static content:
+/// ```dart
+/// TargetContent(
+///   align: ContentAlign.bottom,
+///   padding: EdgeInsets.all(20.0),
+///   child: Column(
+///     children: [
+///       Text("Welcome!", style: TextStyle(fontSize: 20)),
+///       Text("This is your dashboard."),
+///     ],
+///   ),
+/// )
+/// ```
+///
+/// Example with builder:
+/// ```dart
+/// TargetContent(
+///   align: ContentAlign.top,
+///   builder: (context, controller) {
+///     return ElevatedButton(
+///       onPressed: () => controller.next(),
+///       child: Text("Next Step"),
+///     );
+///   },
+/// )
+/// ```
 class TargetContent {
   TargetContent({
     this.align = ContentAlign.bottom,
@@ -35,10 +105,24 @@ class TargetContent {
     this.builder,
   }) : assert(!(align == ContentAlign.custom && customPosition == null));
 
+  /// Where to position this content relative to the target widget.
+  /// When using [ContentAlign.custom], [customPosition] must be provided.
   final ContentAlign align;
+
+  /// Padding around the content widget.
   final EdgeInsets padding;
+
+  /// Custom positioning when [align] is set to [ContentAlign.custom].
+  /// Must be provided when using custom alignment.
   final CustomTargetContentPosition? customPosition;
+
+  /// Static widget to display as content.
+  /// Either [child] or [builder] must be provided, but not both.
   final Widget? child;
+
+  /// Dynamic builder function for creating content.
+  /// Provides access to context and tutorial controller.
+  /// Either [child] or [builder] must be provided, but not both.
   final TargetContentBuilder? builder;
 
   @override

--- a/lib/src/target/target_content.dart
+++ b/lib/src/target/target_content.dart
@@ -25,13 +25,13 @@ class CustomTargetContentPosition {
 
   /// Distance from the top edge of the screen.
   final double? top;
-  
+
   /// Distance from the left edge of the screen.
   final double? left;
-  
+
   /// Distance from the right edge of the screen.
   final double? right;
-  
+
   /// Distance from the bottom edge of the screen.
   final double? bottom;
 
@@ -42,17 +42,21 @@ class CustomTargetContentPosition {
 }
 
 /// Defines where the content should be positioned relative to the target widget.
-enum ContentAlign { 
+enum ContentAlign {
   /// Position content above the target widget.
-  top, 
+  top,
+
   /// Position content below the target widget.
-  bottom, 
+  bottom,
+
   /// Position content to the left of the target widget.
-  left, 
+  left,
+
   /// Position content to the right of the target widget.
-  right, 
+  right,
+
   /// Use custom positioning with [CustomTargetContentPosition].
-  custom 
+  custom
 }
 
 /// Builder function for creating dynamic tutorial content.

--- a/lib/src/target/target_focus.dart
+++ b/lib/src/target/target_focus.dart
@@ -3,6 +3,27 @@ import 'package:tutorial_coach_mark/src/target/target_content.dart';
 import 'package:tutorial_coach_mark/src/target/target_position.dart';
 import 'package:tutorial_coach_mark/src/util.dart';
 
+/// Represents a widget that will be focused during the tutorial.
+///
+/// This class defines a target area in your app that should be highlighted
+/// and focused during the tutorial sequence. Each [TargetFocus] can contain
+/// multiple content pieces that will be displayed around the focused widget.
+///
+/// Example usage:
+/// ```dart
+/// TargetFocus(
+///   identify: "menu_button",
+///   keyTarget: menuButtonKey,
+///   contents: [
+///     TargetContent(
+///       align: ContentAlign.bottom,
+///       child: Text("This is the menu button"),
+///     ),
+///   ],
+///   shape: ShapeLightFocus.RRect,
+///   radius: 10.0,
+/// )
+/// ```
 class TargetFocus {
   TargetFocus({
     this.identify,
@@ -22,20 +43,57 @@ class TargetFocus {
     this.pulseVariation,
   }) : assert(keyTarget != null || targetPosition != null);
 
+  /// Free identifier for this target. Can be used to distinguish between targets.
   final dynamic identify;
+
+  /// [GlobalKey] of the widget that should be focused.
+  /// Either [keyTarget] or [targetPosition] must be provided.
   final GlobalKey? keyTarget;
+
+  /// Custom position for the focus area instead of using [keyTarget].
+  /// Either [keyTarget] or [targetPosition] must be provided.
   final TargetPosition? targetPosition;
+
+  /// List of content pieces to display around the focused widget.
+  /// Each content can be positioned relative to the target (top, bottom, left, right).
   final List<TargetContent>? contents;
+
+  /// Shape of the focus highlight. Can be [ShapeLightFocus.Circle] or [ShapeLightFocus.RRect].
   final ShapeLightFocus? shape;
+
+  /// Corner radius when [shape] is [ShapeLightFocus.RRect].
   final double? radius;
+
+  /// Border configuration for the focus highlight.
   final BorderSide? borderSide;
+
+  /// Enable tap anywhere on the screen overlay to proceed to next step.
+  /// Default is `false`.
   final bool enableOverlayTab;
+
+  /// Enable tap on the target widget to proceed to next step.
+  /// Default is `true`.
   final bool enableTargetTab;
+
+  /// Custom color for this target's focus highlight.
   final Color? color;
+
+  /// Alignment of the skip button relative to this target.
   final AlignmentGeometry? alignSkip;
+
+  /// Padding around the focus area. Overrides the global paddingFocus for this target.
   final double? paddingFocus;
+
+  /// Duration of the focus animation for this target.
+  /// Overrides the global focus animation duration.
   final Duration? focusAnimationDuration;
+
+  /// Duration of the unfocus animation for this target.
+  /// Overrides the global unfocus animation duration.
   final Duration? unFocusAnimationDuration;
+
+  /// Custom pulse animation variation for this target.
+  /// Defines the scale range for the pulse effect (e.g., Tween(begin: 1.0, end: 0.99)).
   final Tween<double>? pulseVariation;
 
   @override

--- a/lib/src/target/target_position.dart
+++ b/lib/src/target/target_position.dart
@@ -1,17 +1,42 @@
 import 'dart:math';
 import 'dart:ui';
 
+/// Defines a custom position and size for a tutorial target when not using [GlobalKey].
+///
+/// Use this class when you want to focus on a specific area of the screen
+/// without relying on a widget's [GlobalKey]. This is useful for highlighting
+/// areas that don't correspond to a specific widget.
+///
+/// Example:
+/// ```dart
+/// TargetPosition(
+///   Size(100, 50),        // width: 100, height: 50
+///   Offset(150, 200),     // x: 150, y: 200
+/// )
+/// ```
 class TargetPosition {
+  /// The size (width and height) of the target area.
   final Size size;
+
+  /// The position (x, y coordinates) of the target area's top-left corner.
   final Offset offset;
 
   TargetPosition(this.size, this.offset);
 
+  /// Gets the center point of the target area.
+  ///
+  /// Calculates the center by adding half the width and height to the offset.
   Offset get center => Offset(
         offset.dx + size.width / 2,
         offset.dy + size.height / 2,
       );
 
+  /// Calculates the maximum distance from the center to any screen border.
+  ///
+  /// This is used internally for animation calculations to ensure the focus
+  /// animation covers the entire screen properly.
+  ///
+  /// [size] The size of the screen or container.
   double getBiggerSpaceBorder(Size size) {
     double maxDistanceX =
         center.dx > size.width / 2 ? center.dx : size.width - center.dx;

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -3,12 +3,14 @@ import 'package:tutorial_coach_mark/src/target/target_focus.dart';
 import 'package:tutorial_coach_mark/src/target/target_position.dart';
 
 /// Defines the shape of the focus highlight around target widgets.
-// ignore: constant_identifier_names
-enum ShapeLightFocus { 
+enum ShapeLightFocus {
   /// Circular highlight shape
-  Circle, 
+// ignore: constant_identifier_names
+  Circle,
+
   /// Rounded rectangle highlight shape
-  RRect 
+// ignore: constant_identifier_names
+  RRect
 }
 
 /// Gets the current position and size of a target widget.
@@ -72,10 +74,10 @@ TargetPosition? getTargetCurrent(
 abstract class TutorialCoachMarkController {
   /// Advances to the next step in the tutorial.
   void next();
-  
+
   /// Goes back to the previous step in the tutorial.
   void previous();
-  
+
   /// Skips the entire tutorial.
   void skip();
 }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -2,9 +2,26 @@ import 'package:flutter/widgets.dart';
 import 'package:tutorial_coach_mark/src/target/target_focus.dart';
 import 'package:tutorial_coach_mark/src/target/target_position.dart';
 
+/// Defines the shape of the focus highlight around target widgets.
 // ignore: constant_identifier_names
-enum ShapeLightFocus { Circle, RRect }
+enum ShapeLightFocus { 
+  /// Circular highlight shape
+  Circle, 
+  /// Rounded rectangle highlight shape
+  RRect 
+}
 
+/// Gets the current position and size of a target widget.
+///
+/// This function calculates the actual position and size of a target widget
+/// on the screen, handling both [GlobalKey] based targets and custom [TargetPosition].
+///
+/// Parameters:
+/// - [target]: The [TargetFocus] to get position for
+/// - [rootOverlay]: Whether to use root overlay for coordinate calculation
+///
+/// Returns the [TargetPosition] or null if the target cannot be found.
+/// Throws [NotFoundTargetException] if the target widget is not found.
 TargetPosition? getTargetCurrent(
   TargetFocus target, {
   bool rootOverlay = false,
@@ -46,13 +63,29 @@ TargetPosition? getTargetCurrent(
   }
 }
 
+/// Abstract controller interface for tutorial coach mark interactions.
+///
+/// This controller provides methods to programmatically control the tutorial
+/// flow from within content builders or external code.
+///
+/// Available through [TargetContentBuilder] callback function.
 abstract class TutorialCoachMarkController {
+  /// Advances to the next step in the tutorial.
   void next();
+  
+  /// Goes back to the previous step in the tutorial.
   void previous();
+  
+  /// Skips the entire tutorial.
   void skip();
 }
 
+/// Extension on [State] to provide safe state updates.
 extension StateExt on State {
+  /// Safely calls [setState] only if the widget is still mounted.
+  ///
+  /// This prevents errors when trying to update state after the widget
+  /// has been disposed or removed from the widget tree.
   void safeSetState(VoidCallback call) {
     if (mounted) {
       // ignore: invalid_use_of_protected_member
@@ -61,16 +94,38 @@ extension StateExt on State {
   }
 }
 
+/// Exception thrown when a target widget cannot be found or positioned.
+///
+/// This typically occurs when:
+/// - The [GlobalKey] is not attached to any widget
+/// - The target widget is not currently in the widget tree
+/// - The widget's render object is not available
 class NotFoundTargetException extends FormatException {
   NotFoundTargetException(identify)
       : super('It was not possible to obtain target position ($identify).');
 }
 
+/// Schedules a callback to run after the current frame.
+///
+/// This is useful for deferring operations until after the widget tree
+/// has been built and painted. Commonly used for initialization tasks
+/// that require the widget to be fully rendered.
 void postFrame(VoidCallback callback) {
   Future.delayed(Duration.zero, callback);
 }
 
+/// Extension on nullable types to provide safe callback execution.
 extension NullableExt<T> on T? {
+  /// Executes the callback only if the value is not null.
+  ///
+  /// This is similar to Kotlin's `let` function and provides a safe way
+  /// to perform operations on nullable values.
+  ///
+  /// Example:
+  /// ```dart
+  /// String? maybeText = getText();
+  /// maybeText.let((text) => print(text)); // Only prints if text is not null
+  /// ```
   void let(Function(T it) callback) {
     if (this != null) {
       callback(this as T);

--- a/lib/src/widgets/animated_focus_light.dart
+++ b/lib/src/widgets/animated_focus_light.dart
@@ -142,7 +142,7 @@ abstract class AnimatedFocusLightState extends State<AnimatedFocusLight>
   /// Used when screen size changes to recalculate target widget positions.
   void refreshTargetPosition() {
     if (_currentFocus < 0) return;
-    
+
     TargetPosition? targetPosition;
     try {
       targetPosition = getTargetCurrent(

--- a/lib/src/widgets/animated_focus_light.dart
+++ b/lib/src/widgets/animated_focus_light.dart
@@ -138,6 +138,33 @@ abstract class AnimatedFocusLightState extends State<AnimatedFocusLight>
     _revertAnimation();
   }
 
+  /// Refreshes the current target position without changing focus.
+  /// Used when screen size changes to recalculate target widget positions.
+  void refreshTargetPosition() {
+    if (_currentFocus < 0) return;
+    
+    TargetPosition? targetPosition;
+    try {
+      targetPosition = getTargetCurrent(
+        _targetFocus,
+        rootOverlay: widget.rootOverlay,
+      );
+    } on NotFoundTargetException catch (e) {
+      debugPrint('Failed to refresh target position: ${e.toString()}');
+      return;
+    }
+
+    if (targetPosition != null) {
+      safeSetState(() {
+        _targetPosition = targetPosition!;
+        _positioned = Offset(
+          targetPosition.offset.dx + (targetPosition.size.width / 2),
+          targetPosition.offset.dy + (targetPosition.size.height / 2),
+        );
+      });
+    }
+  }
+
   Future _tapHandler({
     bool targetTap = false,
     bool overlayTap = false,

--- a/lib/src/widgets/tutorial_coach_mark_widget.dart
+++ b/lib/src/widgets/tutorial_coach_mark_widget.dart
@@ -93,10 +93,10 @@ class TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget>
   @override
   void didChangeMetrics() {
     super.didChangeMetrics();
-    
+
     // Refresh the focus area position for the currently focused target
     _focusLightKey.currentState?.refreshTargetPosition();
-    
+
     // Trigger a rebuild to recalculate content positions
     safeSetState(() {});
   }

--- a/lib/src/widgets/tutorial_coach_mark_widget.dart
+++ b/lib/src/widgets/tutorial_coach_mark_widget.dart
@@ -93,7 +93,12 @@ class TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget>
   @override
   void didChangeMetrics() {
     super.didChangeMetrics();
-    safeSetState((){});
+    
+    // Refresh the focus area position for the currently focused target
+    _focusLightKey.currentState?.refreshTargetPosition();
+    
+    // Trigger a rebuild to recalculate content positions
+    safeSetState(() {});
   }
 
   @override

--- a/lib/src/widgets/tutorial_coach_mark_widget.dart
+++ b/lib/src/widgets/tutorial_coach_mark_widget.dart
@@ -71,10 +71,30 @@ class TutorialCoachMarkWidget extends StatefulWidget {
 }
 
 class TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget>
+    with WidgetsBindingObserver
     implements TutorialCoachMarkController {
   final GlobalKey<AnimatedFocusLightState> _focusLightKey = GlobalKey();
   bool showContent = false;
   TargetFocus? currentTarget;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  /// Called when screen metrics change (orientation, size, etc.)
+  @override
+  void didChangeMetrics() {
+    super.didChangeMetrics();
+    safeSetState((){});
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/tutorial_coach_mark.dart
+++ b/lib/tutorial_coach_mark.dart
@@ -37,6 +37,7 @@ export 'package:tutorial_coach_mark/src/util.dart';
 /// - Support for safe area
 /// - Pulse animation effects
 /// - Custom overlay filters
+/// - Automatic screen resize and orientation handling
 ///
 /// The tutorial can be controlled programmatically using methods like:
 /// - [show] - Displays the tutorial

--- a/lib/tutorial_coach_mark.dart
+++ b/lib/tutorial_coach_mark.dart
@@ -46,33 +46,81 @@ export 'package:tutorial_coach_mark/src/util.dart';
 /// - [finish] - Ends the tutorial
 
 class TutorialCoachMark {
+  /// List of targets to focus during the tutorial sequence.
   final List<TargetFocus> targets;
+
+  /// Callback executed when a target area is tapped.
   final FutureOr<void> Function(TargetFocus)? onClickTarget;
+
+  /// Callback executed when a target is tapped, providing tap position details.
   final FutureOr<void> Function(TargetFocus, TapDownDetails)?
       onClickTargetWithTapPosition;
+
+  /// Callback executed when the overlay area (outside target) is tapped.
   final FutureOr<void> Function(TargetFocus)? onClickOverlay;
+
+  /// Callback executed when the tutorial is completed.
   final Function()? onFinish;
+
+  /// Default padding around focus areas for all targets.
   final double paddingFocus;
 
-  // if onSkip return false, the overlay will not be dismissed and call `next`
+  /// Callback executed when skip button is pressed.
+  /// If returns false, the overlay will not be dismissed and will call `next` instead.
   final bool Function()? onSkip;
+
+  /// Alignment of the skip button on screen.
   final AlignmentGeometry alignSkip;
+
+  /// Text displayed on the skip button.
   final String textSkip;
+
+  /// Text style for the skip button.
   final TextStyle textStyleSkip;
+
+  /// Whether to hide the skip button completely.
   final bool hideSkip;
+
+  /// Whether to respect device safe areas (notches, status bar, etc.).
   final bool useSafeArea;
+
+  /// Color of the shadow overlay behind the tutorial.
   final Color colorShadow;
+
+  /// Opacity of the shadow overlay (0.0 to 1.0).
   final double opacityShadow;
+
+  /// Duration of the focus animation when highlighting a target.
   final Duration focusAnimationDuration;
+
+  /// Duration of the unfocus animation when moving between targets.
   final Duration unFocusAnimationDuration;
+
+  /// Duration of the pulse animation effect on targets.
   final Duration pulseAnimationDuration;
+
+  /// Whether to enable pulse animation on focused targets.
   final bool pulseEnable;
+
+  /// Custom widget to use instead of the default skip button.
   final Widget? skipWidget;
+
+  /// Whether to show the skip button on the last target.
   final bool showSkipInLastTarget;
+
+  /// Image filter effect to apply to the background overlay.
   final ImageFilter? imageFilter;
+
+  /// Semantic label for the background overlay for accessibility.
   final String? backgroundSemanticLabel;
+
+  /// Index of the target to focus initially (0-based).
   final int initialFocus;
+
+  /// Internal widget key for controlling the tutorial widget state.
   final GlobalKey<TutorialCoachMarkWidgetState> _widgetKey = GlobalKey();
+
+  /// Whether to disable the device back button during the tutorial.
   final bool disableBackButton;
 
   OverlayEntry? _overlayEntry;
@@ -80,6 +128,33 @@ class TutorialCoachMark {
       _blockBackRoute; // Referencia a la ruta que bloquea el botón "Atrás"
   BuildContext? _contextTutorial; // Almacena el contexto para usarlo después
 
+  /// Creates a tutorial coach mark with the specified configuration.
+  ///
+  /// Parameters:
+  /// - [targets]: List of target focuses to highlight during the tutorial. Required.
+  /// - [colorShadow]: Color of the shadow overlay. Default is [Colors.black].
+  /// - [onClickTarget]: Callback when target area is tapped.
+  /// - [onClickTargetWithTapPosition]: Callback when target is tapped, provides tap details.
+  /// - [onClickOverlay]: Callback when overlay area (outside target) is tapped.
+  /// - [onFinish]: Callback when tutorial is completed.
+  /// - [paddingFocus]: Padding around focus area. Default is 10.
+  /// - [onSkip]: Callback when skip button is pressed. Return false to prevent skipping.
+  /// - [alignSkip]: Alignment of skip button. Default is [Alignment.bottomRight].
+  /// - [textSkip]: Text for skip button. Default is "SKIP".
+  /// - [textStyleSkip]: Style for skip button text.
+  /// - [hideSkip]: Whether to hide skip button. Default is false.
+  /// - [useSafeArea]: Whether to respect safe areas. Default is true.
+  /// - [opacityShadow]: Opacity of shadow overlay (0.0 to 1.0). Default is 0.8.
+  /// - [focusAnimationDuration]: Duration of focus animation. Default is 600ms.
+  /// - [unFocusAnimationDuration]: Duration of unfocus animation. Default is 600ms.
+  /// - [pulseAnimationDuration]: Duration of pulse animation. Default is 500ms.
+  /// - [pulseEnable]: Whether to enable pulse animation. Default is true.
+  /// - [skipWidget]: Custom widget for skip button.
+  /// - [showSkipInLastTarget]: Whether to show skip in last target. Default is true.
+  /// - [imageFilter]: Image filter effect for background.
+  /// - [initialFocus]: Index of initial focus target. Default is 0.
+  /// - [backgroundSemanticLabel]: Semantic label for background overlay.
+  /// - [disableBackButton]: Whether to disable device back button. Default is false.
   TutorialCoachMark({
     required this.targets,
     this.colorShadow = Colors.black,
@@ -141,6 +216,14 @@ class TutorialCoachMark {
     );
   }
 
+  /// Displays the tutorial using the provided build context.
+  ///
+  /// This is the primary method for showing the tutorial. It automatically
+  /// finds the appropriate overlay state from the context.
+  ///
+  /// Parameters:
+  /// - [context]: The build context to find overlay state from.
+  /// - [rootOverlay]: Whether to use the root overlay instead of nearest overlay.
   void show({required BuildContext context, bool rootOverlay = false}) {
     OverlayState? overlay = Overlay.of(context, rootOverlay: rootOverlay);
     overlay.let((it) {
@@ -148,6 +231,14 @@ class TutorialCoachMark {
     });
   }
 
+  /// Displays the tutorial using a specific navigator state key.
+  ///
+  /// Use this when you need to show the tutorial on a specific navigator
+  /// instead of using the current build context.
+  ///
+  /// Parameters:
+  /// - [navigatorKey]: The global key of the navigator state.
+  /// - [rootOverlay]: Whether to use the root overlay.
   void showWithNavigatorStateKey({
     required GlobalKey<NavigatorState> navigatorKey,
     bool rootOverlay = false,
@@ -160,6 +251,14 @@ class TutorialCoachMark {
     });
   }
 
+  /// Displays the tutorial using a specific overlay state.
+  ///
+  /// This provides the most control over where the tutorial is displayed.
+  /// Use when you have direct access to the overlay state.
+  ///
+  /// Parameters:
+  /// - [overlay]: The overlay state to insert the tutorial into.
+  /// - [rootOverlay]: Whether to use root overlay positioning.
   void showWithOverlayState({
     required OverlayState overlay,
     bool rootOverlay = false,
@@ -196,11 +295,18 @@ class TutorialCoachMark {
     }
   }
 
+  /// Finishes the tutorial and removes the overlay.
+  ///
+  /// Calls the [onFinish] callback if provided, then removes the tutorial overlay.
   void finish() {
     onFinish?.call();
     _removeOverlay();
   }
 
+  /// Skips the tutorial.
+  ///
+  /// Calls the [onSkip] callback if provided. If the callback returns false,
+  /// the tutorial will proceed to the next step instead of closing.
   void skip() {
     bool removeOverlay = onSkip?.call() ?? true;
     if (removeOverlay) {
@@ -210,14 +316,22 @@ class TutorialCoachMark {
     }
   }
 
+  /// Whether the tutorial is currently being displayed.
   bool get isShowing => _overlayEntry != null;
 
+  /// Internal widget key for accessing tutorial state.
   GlobalKey<TutorialCoachMarkWidgetState> get widgetKey => _widgetKey;
 
+  /// Advances to the next target in the tutorial sequence.
   void next() => _widgetKey.currentState?.next();
 
+  /// Goes back to the previous target in the tutorial sequence.
   void previous() => _widgetKey.currentState?.previous();
 
+  /// Jumps directly to a specific target by index.
+  ///
+  /// Parameters:
+  /// - [index]: Zero-based index of the target to jump to.
   void goTo(int index) => _widgetKey.currentState?.goTo(index);
 
   void _removeOverlay() {


### PR DESCRIPTION
# Description

Added inline documentation so while developing you can read what fields do without having to refer to readme

Add auto resizing of content widget when the screen/parent widget resizes

Add auto refocusing of the focus widget on screen resize, as this will generally result in the focused widget to move

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I open this PR to the `develop` branch.

> I havn't done this as it seems like the develop branch is quite out of date?

- [ ] I have added a description of the change under `[next]` in `CHANGELOG.md`.

> Also havn't sorry but don't want to push up a changelog to master with next in it.

- [ ] I ran `flutter format --set-exit-if-changed --dry-run .` and has success.

> I believe this is `dart format --output=none --set-exit-if-changed .` , but yes I have ran this

## Breaking Change

Does your PR require Flame users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in `CHANGELOG.md`).
- [x] No, this is *not* a breaking change.