### PR TITLE
fix: overlay semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 1.3.3
 - Fix: Custom skipWidget not triggering tutorial skip action #222
 - Inline documentation, enable rebuilding on screen resize #226
-- Fix: Exclude non-tappable shadow overlay from semantics so screen readers do not announce a nameless "Button" on the dimmed background.
+- Fix: Exclude shadow overlay from semantics until tooltip content is visible, and when the overlay is non-tappable, so screen readers do not announce a nameless "Button" on the dimmed background.
 
 # 1.3.2
 - Adds before focus function so that something can be run before focusing on the next target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
-# 1.3.3.1
-- Fix: Exclude non-tappable shadow overlay from semantics so screen readers do not announce a nameless "Button" on the dimmed background.
-
 # 1.3.3
 - Fix: Custom skipWidget not triggering tutorial skip action #222
 - Inline documentation, enable rebuilding on screen resize #226
+- Fix: Exclude non-tappable shadow overlay from semantics so screen readers do not announce a nameless "Button" on the dimmed background.
 
 # 1.3.2
 - Adds before focus function so that something can be run before focusing on the next target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.3.3.1
+- Fix: Exclude non-tappable shadow overlay from semantics so screen readers do not announce a nameless "Button" on the dimmed background.
+
 # 1.3.3
 - Fix: Custom skipWidget not triggering tutorial skip action #222
 - Inline documentation, enable rebuilding on screen resize #226

--- a/lib/src/widgets/animated_focus_light.dart
+++ b/lib/src/widgets/animated_focus_light.dart
@@ -342,9 +342,9 @@ class AnimatedStaticFocusLightState extends AnimatedFocusLightState {
 
   @override
   Widget build(BuildContext context) {
-    return Semantics(
-      label: widget.backgroundSemanticLabel,
-      button: true,
+    return _withBackgroundSemantics(
+      enableOverlayTab: _targetFocus.enableOverlayTab,
+      backgroundSemanticLabel: widget.backgroundSemanticLabel,
       child: InkWell(
         excludeFromSemantics: true,
         onTap: _targetFocus.enableOverlayTab
@@ -436,9 +436,9 @@ class AnimatedPulseFocusLightState extends AnimatedFocusLightState {
 
   @override
   Widget build(BuildContext context) {
-    return Semantics(
-      label: widget.backgroundSemanticLabel,
-      button: true,
+    return _withBackgroundSemantics(
+      enableOverlayTab: _targetFocus.enableOverlayTab,
+      backgroundSemanticLabel: widget.backgroundSemanticLabel,
       child: InkWell(
         excludeFromSemantics: true,
         onTap: _targetFocus.enableOverlayTab
@@ -545,4 +545,23 @@ class AnimatedPulseFocusLightState extends AnimatedFocusLightState {
       CurvedAnimation(parent: _controllerPulse, curve: Curves.ease),
     );
   }
+}
+
+/// Background overlay semantics: interactive only when the overlay accepts taps.
+Widget _withBackgroundSemantics({
+  required bool enableOverlayTab,
+  required String? backgroundSemanticLabel,
+  required Widget child,
+}) {
+  if (!enableOverlayTab) {
+    return ExcludeSemantics(child: child);
+  }
+  if (backgroundSemanticLabel == null) {
+    return ExcludeSemantics(child: child);
+  }
+  return Semantics(
+    label: backgroundSemanticLabel,
+    button: true,
+    child: child,
+  );
 }

--- a/lib/src/widgets/animated_focus_light.dart
+++ b/lib/src/widgets/animated_focus_light.dart
@@ -33,6 +33,7 @@ class AnimatedFocusLight extends StatefulWidget {
     this.rootOverlay = false,
     this.initialFocus = 0,
     this.backgroundSemanticLabel,
+    this.tooltipVisible = false,
   })  : assert(targets.length > 0),
         super(key: key);
 
@@ -57,6 +58,7 @@ class AnimatedFocusLight extends StatefulWidget {
   final ImageFilter? imageFilter;
   final int initialFocus;
   final String? backgroundSemanticLabel;
+  final bool tooltipVisible;
 
   @override
   // ignore: no_logic_in_create_state
@@ -345,6 +347,7 @@ class AnimatedStaticFocusLightState extends AnimatedFocusLightState {
     return _withBackgroundSemantics(
       enableOverlayTab: _targetFocus.enableOverlayTab,
       backgroundSemanticLabel: widget.backgroundSemanticLabel,
+      tooltipVisible: widget.tooltipVisible,
       child: InkWell(
         excludeFromSemantics: true,
         onTap: _targetFocus.enableOverlayTab
@@ -439,6 +442,7 @@ class AnimatedPulseFocusLightState extends AnimatedFocusLightState {
     return _withBackgroundSemantics(
       enableOverlayTab: _targetFocus.enableOverlayTab,
       backgroundSemanticLabel: widget.backgroundSemanticLabel,
+      tooltipVisible: widget.tooltipVisible,
       child: InkWell(
         excludeFromSemantics: true,
         onTap: _targetFocus.enableOverlayTab
@@ -547,12 +551,17 @@ class AnimatedPulseFocusLightState extends AnimatedFocusLightState {
   }
 }
 
-/// Background overlay semantics: interactive only when the overlay accepts taps.
+/// Background overlay semantics: exposed only once tooltip content is visible
+/// and the overlay accepts taps.
 Widget _withBackgroundSemantics({
   required bool enableOverlayTab,
   required String? backgroundSemanticLabel,
+  required bool tooltipVisible,
   required Widget child,
 }) {
+  if (!tooltipVisible) {
+    return ExcludeSemantics(child: child);
+  }
   if (!enableOverlayTab) {
     return ExcludeSemantics(child: child);
   }

--- a/lib/src/widgets/tutorial_coach_mark_widget.dart
+++ b/lib/src/widgets/tutorial_coach_mark_widget.dart
@@ -126,6 +126,7 @@ class TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget>
             rootOverlay: widget.rootOverlay,
             imageFilter: widget.imageFilter,
             backgroundSemanticLabel: widget.backgroundSemanticLabel,
+            tooltipVisible: showContent,
             clickTarget: (target) {
               return widget.clickTarget?.call(target);
             },

--- a/lib/src/widgets/tutorial_coach_mark_widget.dart
+++ b/lib/src/widgets/tutorial_coach_mark_widget.dart
@@ -36,6 +36,8 @@ class TutorialCoachMarkWidget extends StatefulWidget {
     this.showSkipInLastTarget = false,
     this.imageFilter,
     this.backgroundSemanticLabel,
+    this.contentAnimationDuration = const Duration(milliseconds: 300),
+    this.contentAlwaysIncludeSemantics = false,
     this.initialFocus = 0,
   })  : assert(targets.length > 0),
         super(key: key);
@@ -67,6 +69,8 @@ class TutorialCoachMarkWidget extends StatefulWidget {
   final ImageFilter? imageFilter;
   final int initialFocus;
   final String? backgroundSemanticLabel;
+  final Duration contentAnimationDuration;
+  final bool contentAlwaysIncludeSemantics;
 
   @override
   TutorialCoachMarkWidgetState createState() => TutorialCoachMarkWidgetState();
@@ -151,7 +155,10 @@ class TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget>
           ),
           AnimatedOpacity(
             opacity: showContent ? 1 : 0,
-            duration: const Duration(milliseconds: 300),
+            duration: MediaQuery.disableAnimationsOf(context)
+                ? Duration.zero
+                : widget.contentAnimationDuration,
+            alwaysIncludeSemantics: widget.contentAlwaysIncludeSemantics,
             child: _buildContents(),
           ),
           _buildSkip()
@@ -309,7 +316,10 @@ class TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget>
         right: widget.useSafeArea ? true : false,
         child: AnimatedOpacity(
           opacity: showContent ? 1 : 0,
-          duration: Durations.medium2,
+          duration: MediaQuery.disableAnimationsOf(context)
+              ? Duration.zero
+              : widget.contentAnimationDuration,
+          alwaysIncludeSemantics: widget.contentAlwaysIncludeSemantics,
           child: widget.skipWidget != null
               ? InkWell(
             onTap: skip,

--- a/lib/tutorial_coach_mark.dart
+++ b/lib/tutorial_coach_mark.dart
@@ -118,6 +118,16 @@ class TutorialCoachMark {
   /// Semantic label for the background overlay for accessibility.
   final String? backgroundSemanticLabel;
 
+  /// Duration of the content fade-in animation when a target is focused.
+  final Duration contentAnimationDuration;
+
+  /// Whether to include step content in the semantics tree during fade-in.
+  ///
+  /// When false (default), [AnimatedOpacity] omits child semantics while
+  /// opacity is 0. Set to true when screen readers need immediate access to
+  /// tooltip content before the fade completes.
+  final bool contentAlwaysIncludeSemantics;
+
   /// Index of the target to focus initially (0-based).
   final int initialFocus;
 
@@ -158,6 +168,9 @@ class TutorialCoachMark {
   /// - [imageFilter]: Image filter effect for background.
   /// - [initialFocus]: Index of initial focus target. Default is 0.
   /// - [backgroundSemanticLabel]: Semantic label for background overlay.
+  /// - [contentAnimationDuration]: Duration of content fade-in. Default is 300ms.
+  /// - [contentAlwaysIncludeSemantics]: Include content semantics during fade-in.
+  ///   Default is false.
   /// - [disableBackButton]: Whether to disable device back button. Default is false.
   TutorialCoachMark({
     required this.targets,
@@ -184,6 +197,8 @@ class TutorialCoachMark {
     this.imageFilter,
     this.initialFocus = 0,
     this.backgroundSemanticLabel,
+    this.contentAnimationDuration = const Duration(milliseconds: 300),
+    this.contentAlwaysIncludeSemantics = false,
     this.disableBackButton = false,
   }) : assert(opacityShadow >= 0 && opacityShadow <= 1);
 
@@ -217,6 +232,8 @@ class TutorialCoachMark {
           imageFilter: imageFilter,
           initialFocus: initialFocus,
           backgroundSemanticLabel: backgroundSemanticLabel,
+          contentAnimationDuration: contentAnimationDuration,
+          contentAlwaysIncludeSemantics: contentAlwaysIncludeSemantics,
         );
       },
     );


### PR DESCRIPTION
# Description

Exclude non-tappable shadow overlay from semantics so screen readers do not announce a nameless "Button" on the dimmed background.