### PR TITLE
fix: tap race, pulse delay and missing-target handling (issues #235 #175 #183 #218 #223 #199 #219)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# next
+- Fix: `next()`/`finish()` no longer waits for the pulse animation to end before playing the unfocus animation. [#235](https://github.com/RafaelBarbosatec/tutorial_coach_mark/issues/235)
+- Fix: rapid taps on the overlay or target no longer skip multiple steps. [#175](https://github.com/RafaelBarbosatec/tutorial_coach_mark/issues/175) [#183](https://github.com/RafaelBarbosatec/tutorial_coach_mark/issues/183)
+- Fix: the tutorial no longer aborts when a target cannot be found (conditional widgets, targets removed after a tap, scrolled off-screen). It now skips to the next available target and only finishes when none remain. [#218](https://github.com/RafaelBarbosatec/tutorial_coach_mark/issues/218) [#223](https://github.com/RafaelBarbosatec/tutorial_coach_mark/issues/223) [#199](https://github.com/RafaelBarbosatec/tutorial_coach_mark/issues/199)
+- Fix: `onClickTarget` callbacks are deferred one microtask so Navigator operations (`push`, `pop`, `pushReplacement`) no longer run while the navigator is locked. [#219](https://github.com/RafaelBarbosatec/tutorial_coach_mark/issues/219)
+- Hardening: `getTargetCurrent` reports a missing target context as `NotFoundTargetException` (handled) instead of crashing with a null-check error.
+
 # 1.3.3
 - Fix: Custom skipWidget not triggering tutorial skip action #222
 - Inline documentation, enable rebuilding on screen resize #226

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -30,19 +30,25 @@ TargetPosition? getTargetCurrent(
 }) {
   if (target.keyTarget != null) {
     var key = target.keyTarget!;
+    final keyContext = key.currentContext;
+    if (keyContext == null) {
+      // The widget is no longer in the tree (removed, conditional render,
+      // scrolled out of a lazy list, etc.). Report it as a regular
+      // NotFoundTargetException instead of crashing with a null-check error.
+      throw NotFoundTargetException(target.identify);
+    }
 
     try {
-      final RenderBox renderBoxRed =
-          key.currentContext!.findRenderObject() as RenderBox;
+      final RenderBox renderBoxRed = keyContext.findRenderObject() as RenderBox;
       final size = renderBoxRed.size;
 
       BuildContext? context;
       if (rootOverlay) {
-        context = key.currentContext!
+        context = keyContext
             .findRootAncestorStateOfType<OverlayState>()
             ?.context;
       } else {
-        context = key.currentContext!
+        context = keyContext
             .findAncestorStateOfType<NavigatorState>()
             ?.context;
       }

--- a/lib/src/widgets/animated_focus_light.dart
+++ b/lib/src/widgets/animated_focus_light.dart
@@ -555,7 +555,7 @@ class AnimatedPulseFocusLightState extends AnimatedFocusLightState {
 
       widget.focus?.call(_targetFocus);
 
-      _controllerPulse.forward();
+      _controllerPulse.forward(from: 0.0);
     }
     if (status == AnimationStatus.dismissed) {
       _finishFocus = false;
@@ -574,7 +574,7 @@ class AnimatedPulseFocusLightState extends AnimatedFocusLightState {
 
     if (status == AnimationStatus.dismissed) {
       if (_finishFocus) {
-        _controllerPulse.forward();
+        _controllerPulse.forward(from: 0.0);
       }
     }
   }

--- a/lib/src/widgets/animated_focus_light.dart
+++ b/lib/src/widgets/animated_focus_light.dart
@@ -172,8 +172,15 @@ abstract class AnimatedFocusLightState extends State<AnimatedFocusLight>
     bool overlayTap = false,
   }) async {
     if (_isAnimating) return;
+    // Guard synchronously BEFORE any await: rapid taps must not advance
+    // multiple steps while the user callback is still running (#175, #183).
+    _isAnimating = true;
     nextIndex++;
     if (targetTap) {
+      // Defer so Navigator operations (push/pop/pushReplacement) inside the
+      // callback do not run while the navigator is locked (e.g. during a
+      // route transition), which throws a _debugLocked assertion (#219).
+      await Future<void>.delayed(Duration.zero);
       await widget.clickTarget?.call(_targetFocus);
     }
     if (overlayTap) {
@@ -209,7 +216,7 @@ abstract class AnimatedFocusLightState extends State<AnimatedFocusLight>
     }
 
     if (targetPosition == null) {
-      _finish();
+      skipToNextAvailable();
       return;
     }
 
@@ -241,9 +248,41 @@ abstract class AnimatedFocusLightState extends State<AnimatedFocusLight>
     }
   }
 
+  /// Advances to the next target whose widget is currently available,
+  /// skipping targets that cannot be found (conditionally rendered, removed
+  /// after an interaction, scrolled off-screen, etc.). The tutorial finishes
+  /// only when no remaining target is available (#218, #223, #199).
+  void skipToNextAvailable() {
+    var index = nextIndex;
+    while (index < widget.targets.length) {
+      if (index == _currentFocus) {
+        index++;
+        continue;
+      }
+
+      TargetPosition? position;
+      try {
+        position = getTargetCurrent(
+          widget.targets[index],
+          rootOverlay: widget.rootOverlay,
+        );
+      } on NotFoundTargetException {
+        position = null;
+      }
+
+      if (position != null) {
+        nextIndex = index;
+        _goToFocus(index);
+        return;
+      }
+      index++;
+    }
+    _finish();
+  }
+
   void _finish() {
     safeSetState(() => _currentFocus = 0);
-    widget.finish!();
+    widget.finish?.call();
   }
 
   Widget _getLightPaint(TargetFocus targetFocus) {
@@ -407,7 +446,6 @@ class AnimatedPulseFocusLightState extends AnimatedFocusLightState {
   late Animation _tweenPulse;
 
   bool _finishFocus = false;
-  bool _initReverse = false;
 
   get left => (_targetPosition?.offset.dx ?? 0) - _getPaddingFocus() * 2;
 
@@ -495,8 +533,13 @@ class AnimatedPulseFocusLightState extends AnimatedFocusLightState {
   @override
   Future<void> _revertAnimation() async {
     await super._revertAnimation();
-    _initReverse = true;
-    return _controllerPulse.reverse(from: _controllerPulse.value);
+    // Stop the pulse loop immediately and play the unfocus animation right
+    // away. Previously the reverse waited for the pulse controller to finish
+    // reversing, which delayed next()/finish() by up to a full pulse cycle
+    // (issue #235).
+    _finishFocus = false;
+    _controllerPulse.stop();
+    return _controller.reverse();
   }
 
   @override
@@ -516,7 +559,6 @@ class AnimatedPulseFocusLightState extends AnimatedFocusLightState {
     }
     if (status == AnimationStatus.dismissed) {
       _finishFocus = false;
-      _initReverse = false;
       _goToFocus(nextIndex);
     }
 
@@ -531,10 +573,7 @@ class AnimatedPulseFocusLightState extends AnimatedFocusLightState {
     }
 
     if (status == AnimationStatus.dismissed) {
-      if (_initReverse) {
-        safeSetState(() => _finishFocus = false);
-        _controller.reverse();
-      } else if (_finishFocus) {
+      if (_finishFocus) {
         _controllerPulse.forward();
       }
     }

--- a/lib/src/widgets/tutorial_coach_mark_widget.dart
+++ b/lib/src/widgets/tutorial_coach_mark_widget.dart
@@ -173,11 +173,17 @@ class TutorialCoachMarkWidgetState extends State<TutorialCoachMarkWidget>
         rootOverlay: widget.rootOverlay,
       );
     } on NotFoundTargetException catch (e) {
-      skip();
-
-      ///error tutorial exit
       debugPrint("  error>>>>> e ${e.toString()}");
-      //debugPrintStack(stackTrace: s);
+
+      // The current target is not (or is no longer) available — e.g. it was
+      // removed by the app after a tap, rendered conditionally, or scrolled
+      // off-screen. Skip to the next available target instead of aborting
+      // the whole tutorial (#218, #223, #199).
+      postFrame(() {
+        if (mounted) {
+          _focusLightKey.currentState?.skipToNextAvailable();
+        }
+      });
     }
 
     if (target == null) {


### PR DESCRIPTION
## Summary

Fixes four groups of real bugs found by tracing the animation/tap state machine in `AnimatedFocusLightState`:

### 1. #235 — `next()` delayed until the pulse animation ends
`AnimatedPulseFocusLightState._revertAnimation()` waited for `_controllerPulse.reverse()` to complete before reversing the main (unfocus) controller — with a long `pulseAnimationDuration` (or even the default 500ms), every `next()`/`finish()` felt unresponsive.
**Fix:** stop the pulse controller immediately, clear `_finishFocus`, and reverse the unfocus animation right away. The pulse loop itself (completed → reverse → dismissed → forward) is unchanged.

### 2. #175 + #183 — rapid taps skip multiple steps
`_tapHandler()` checked `_isAnimating` but then `await`ed the user's `clickTarget` callback *before* `_revertAnimation()` set the guard. A second tap during that await passed the guard and incremented `nextIndex` again.
**Fix:** set `_isAnimating = true` synchronously before any `await`.

### 3. #218 + #223 + #199 — missing target aborts the whole tutorial
When `getTargetCurrent` failed, `_runFocus` called `_finish()` and `_buildContents` called `skip()` — so a target that was conditionally rendered, removed after a tap, or scrolled off-screen killed the tutorial with `FormatException: It was not possible to obtain target position (...)`.
**Fix:** new `skipToNextAvailable()` scans forward for the next target whose position can be resolved, and only finishes when no remaining target is available. `_buildContents` schedules it post-frame (can't advance during build).

### 4. #219 — Navigator ops in `onClickTarget` → `_debugLocked` assertion
**Fix (defensive):** the `clickTarget` callback is deferred one microtask so Navigator `push`/`pop`/`pushReplacement` don't run while the navigator is locked. ⚠️ This mitigates the mid-frame case; if the tap happens during an active route transition, deferring a microtask may not be enough — please verify on device and comment if it persists.

### Hardening
`getTargetCurrent` now throws the handled `NotFoundTargetException` when a target's `GlobalKey` context is gone, instead of crashing with a raw null-check error.

## Notes
- No CI on this repo and no Flutter SDK available on the author's machine, so **these changes were not executed** — they are reviewed against the state machine trace but should be validated with `flutter test`/`flutter analyze` before release.
- The repo's test file (`test/tutorial_coach_mark_test.dart`) is currently empty — happy to follow up with a small widget-test suite that exercises tap/next/missing-target flows if useful.

## Commits
- `2fd0c55` fix: resolve tutorial control bugs (tap race, pulse delay, missing targets)
- `744f29a` docs: update CHANGELOG with bug fixes
